### PR TITLE
gh: Install protoc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,14 +17,15 @@ jobs:
           - nightly
         os:
           - ubuntu-latest
-          - macos-latest
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Code checkout
+      uses: actions/checkout@v3
 
-    - uses: actions-rs/toolchain@v1
+    - name: Rust toolchain installation
+      uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: ${{ matrix.rust }}
@@ -32,14 +33,18 @@ jobs:
         components: rustfmt, clippy
         target: x86_64-unknown-linux-gnu
 
-    - name: build
+    - name: Protocol buffer compiler installation
+      run: |
+        sudo apt-get update && sudo apt-get install -y protobuf-compiler libprotobuf-dev
+
+    - name: Build
       run: make kbs
 
-    - name: lint
+    - name: Lint
       run: make lint
 
-    - name: format
+    - name: Format
       run: make format
 
-    - name: test
+    - name: Test
       run: make check


### PR DESCRIPTION
In order to generate the attestation service gRPC bindings.

Signed-off-by: Samuel Ortiz <sameo@rivosinc.com>