### PR TITLE
Feat resource registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-httpauth"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dda62cf04bc3a9ad2ea8f314f721951cfdb4cdacec4e984d20e77c7bb170991"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "base64 0.13.1",
+ "futures-core",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,12 +323,14 @@ name = "api-server"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "actix-web-httpauth",
  "aes-gcm",
  "anyhow",
  "async-trait",
  "attestation-service",
  "base64 0.13.1",
  "env_logger 0.10.0",
+ "jwt-simple",
  "kbs-types 0.1.0 (git+https://github.com/virtee/kbs-types.git?rev=13b9378f)",
  "lazy_static",
  "log",
@@ -421,6 +438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +483,12 @@ dependencies = [
  "shlex",
  "which",
 ]
+
+[[package]]
+name = "binstring"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0d60973d9320722cb1206f412740e162a33b8547ea8d6be75d7cff237c7a85"
 
 [[package]]
 name = "bitflags"
@@ -699,6 +728,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "coarsetime"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90d114103adbc625300f346d4d09dfb4ab1c4a8df6868435dd903392ecf4354"
+dependencies = [
+ "libc",
+ "once_cell",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +887,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +908,12 @@ dependencies = [
  "rand_core",
  "typenum",
 ]
+
+[[package]]
+name = "ct-codecs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "ctr"
@@ -922,7 +981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid 0.7.1",
- "crypto-bigint",
+ "crypto-bigint 0.3.2",
  "pem-rfc7468 0.3.1",
 ]
 
@@ -968,6 +1027,29 @@ dependencies = [
  "block-buffer",
  "const-oid 0.9.1",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.0.0",
+]
+
+[[package]]
+name = "ed25519-compact"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
+dependencies = [
+ "ct-codecs",
+ "getrandom",
 ]
 
 [[package]]
@@ -975,6 +1057,28 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468 0.6.0",
+ "pkcs8 0.9.0",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1039,6 +1143,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -1253,6 +1367,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1437,48 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hmac-sha1-compact"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e2440a0078e20c3b68ca01234cea4219f23e64b0c0bdb1200c5550d54239bb"
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc736091aacb31ddaa4cd5f6988b3c21e99913ac846b41f32538c5fae5d71bfe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hmac-sha512"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520c9c3f6040661669bc5c91e551b605a520c8e0a63a766a91a65adef734d151"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1571,6 +1738,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwt-simple"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff4ddff10e7804e02c30026b6848dc7eef2753545e7e79266d114e4fd6266a4"
+dependencies = [
+ "anyhow",
+ "binstring",
+ "coarsetime",
+ "ct-codecs",
+ "ed25519-compact",
+ "hmac-sha1-compact",
+ "hmac-sha256",
+ "hmac-sha512",
+ "k256",
+ "p256",
+ "p384",
+ "rand",
+ "rsa 0.7.2",
+ "serde",
+ "serde_json",
+ "spki 0.6.0",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "k256"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a55e0ff3b72c262bcf041d9e97f1b84492b68f1c1a384de2323d3dc9403397"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -1942,6 +2149,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "p256"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2378,15 @@ checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b54f7131b3dba65a2f414cf5bd25b66d4682e4608610668eae785750ba4c5b2"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2367,6 +2607,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,7 +2680,7 @@ dependencies = [
  "pkcs1 0.4.1",
  "pkcs8 0.9.0",
  "rand_core",
- "signature",
+ "signature 1.6.4",
  "smallvec",
  "subtle",
  "zeroize",
@@ -2555,6 +2806,20 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring 0.16.20",
  "untrusted 0.7.1",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2700,6 +2965,16 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "signature"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest",
  "rand_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "tempfile",
  "tokio",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "actix-web",
  "aes-gcm",
  "anyhow",
+ "async-trait",
  "attestation-service",
  "base64 0.13.1",
  "env_logger 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ env_logger = "0.10.0"
 log = "0.4.17"
 serde_json = "1.0.89"
 tokio = { version = "1.23.0", features = ["full"] }
+
+[workspace.dev-dependencies]
+tempfile = "3.4.0"

--- a/docs/kbs.yaml
+++ b/docs/kbs.yaml
@@ -118,6 +118,32 @@ paths:
           description: The KBC is not allowed to get that resource
         404:
           description: The requested resource does not exist
+    post:
+      operationId: registerSecretResource
+      summary: Register a secret resource into the Key Broker Service.
+      requestBody:
+        required: true
+        content: *
+      parameters:
+        - name: repository
+          in: path
+          description: A parent path of resource, can be empty to use the default repository.
+          schema:
+            type: string
+          required: false
+        - name: type
+          in: path
+          description: Resource type name
+          schema:
+            type: string
+          required: true
+        - name: tag
+          in: path
+          description: Resource instance tag
+          schema:
+            type: string
+          required: true
+        - name: 
   /resource/token/{tag}:
     get:
       operationId: getToken

--- a/docs/kbs_attestation_protocol.md
+++ b/docs/kbs_attestation_protocol.md
@@ -405,6 +405,11 @@ specific resource instance belongs to the KBS and its underlying attestation ser
 The decision is typically based on both the attestation evidence, results and
 provisioned policies for a given attester.
 
+#### Resource Registration (Experimental)
+
+A POST request with the content of resource to `/kbs/v0/resource/<repository>/<type>/<tag>` can register the resource into the KBS.
+
+
 ### Token Resource
 
 Authenticated attesters can also request a token from the KBS.

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -14,6 +14,7 @@ no-verifier = ["attestation-service/in-toto", "attestation-service/rvps-server"]
 actix-web = { version = "4", features = ["rustls"] }
 aes-gcm = "0.10.1"
 anyhow.workspace = true
+async-trait.workspace = true
 attestation-service.workspace = true
 base64.workspace = true
 env_logger.workspace = true

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -12,12 +12,14 @@ no-verifier = ["attestation-service/in-toto", "attestation-service/rvps-server"]
 
 [dependencies]
 actix-web = { version = "4", features = ["rustls"] }
+actix-web-httpauth = "0.8.0"
 aes-gcm = "0.10.1"
 anyhow.workspace = true
 async-trait.workspace = true
 attestation-service.workspace = true
 base64.workspace = true
 env_logger.workspace = true
+jwt-simple = "0.11.4"
 lazy_static = "1.4.0"
 log.workspace = true
 kbs-types = { git = "https://github.com/virtee/kbs-types.git", rev = "13b9378f" }

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -32,3 +32,6 @@ strum = "0.24.1"
 strum_macros = "0.24.1"
 tokio.workspace = true
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+
+[dev-dependencies]
+tempfile.dev-workspace = true

--- a/src/api_server/src/auth.rs
+++ b/src/api_server/src/auth.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use actix_web::http::header::Header;
+use actix_web::HttpRequest;
+use actix_web_httpauth::headers::authorization::{Authorization, Bearer};
+use anyhow::{Context, Result};
+use jwt_simple::prelude::{
+    Ed25519PublicKey, EdDSAPublicKeyLike, NoCustomClaims, VerificationOptions,
+};
+
+pub(crate) fn validate_auth(request: &HttpRequest, public_key: &Ed25519PublicKey) -> Result<()> {
+    let bearer = Authorization::<Bearer>::parse(request)
+        .context("parse Authorization header failed")?
+        .into_scheme();
+
+    let token = bearer.token();
+
+    let _claims = public_key
+        .verify_token::<NoCustomClaims>(token, Some(VerificationOptions::default()))
+        .context("token verification failed")?;
+
+    Ok(())
+}

--- a/src/api_server/src/http.rs
+++ b/src/api_server/src/http.rs
@@ -202,7 +202,9 @@ pub(crate) async fn resource(
         session.tee_public_key().unwrap(),
         repository.get_ref(),
         resource_description,
-    ) {
+    )
+    .await
+    {
         Ok(response) => HttpResponse::Ok()
             .content_type("application/json")
             .body(serde_json::to_string(&response).unwrap()),

--- a/src/api_server/src/http.rs
+++ b/src/api_server/src/http.rs
@@ -141,7 +141,7 @@ pub(crate) async fn attest(
 
 /// GET /resource/{repository}/{type}/{tag}
 /// GET /resource/{type}/{tag}
-pub(crate) async fn resource(
+pub(crate) async fn get_resource(
     request: HttpRequest,
     repository: web::Data<Arc<dyn Repository + Send + Sync>>,
     map: web::Data<SessionMap<'_>>,

--- a/src/api_server/src/http.rs
+++ b/src/api_server/src/http.rs
@@ -218,10 +218,13 @@ pub(crate) async fn get_resource(
 /// POST /resource/{repository}/{type}/{tag}
 /// POST /resource/{type}/{tag}
 ///
-/// TODO: This API surely needs identification check, only the owner of this repo
-/// or the owner of this KBS can call. The identification mechinism remains
-/// undesigned and unimplemented. Now it can be called by anyone, which is very
-/// dangerous and only for test.
+/// TODO: Although this endpoint is authenticated through a JSON Web Token (JWT),
+/// only identified users should be able to get a JWT and access it.
+/// At the moment user identification is not supported, and the KBS CLI
+/// `--user-public-key` defines the authorized user for that endpoint. In other words,
+/// any JWT signed with the user's private key will be authenticated.
+/// JWT generation and user identification is unimplemented for now, and thus this
+/// endpoint is insecure and is only meant for testing purposes.
 pub(crate) async fn set_resource(
     request: HttpRequest,
     data: web::Bytes,

--- a/src/api_server/src/http.rs
+++ b/src/api_server/src/http.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use strum_macros::EnumString;
 use tokio::sync::Mutex;
 
-use crate::resource::{secret_resource, Repository, ResourceDesc};
+use crate::resource::{get_secret_resource, Repository, ResourceDesc};
 use crate::session::{Session, SessionMap, KBS_SESSION_ID};
 
 const ERROR_TYPE_PREFIX: &str = "https://github.com/confidential-containers/kbs/errors/";
@@ -198,7 +198,7 @@ pub(crate) async fn resource(
         internal!(format!("TEE Pubkey not found"));
     }
 
-    match secret_resource(
+    match get_secret_resource(
         session.tee_public_key().unwrap(),
         repository.get_ref(),
         resource_description,

--- a/src/api_server/src/http.rs
+++ b/src/api_server/src/http.rs
@@ -247,6 +247,6 @@ pub(crate) async fn set_resource(
 
     match set_secret_resource(&repository, resource_description, data.as_ref()).await {
         Ok(_) => HttpResponse::Ok().content_type("application/json").body(""),
-        Err(e) => internal!(format!("Registry Resource failed: {e}")),
+        Err(e) => internal!(format!("Resource registration failed: {e}")),
     }
 }

--- a/src/api_server/src/http.rs
+++ b/src/api_server/src/http.rs
@@ -7,7 +7,7 @@ use attestation_service::AttestationService;
 use kbs_types::{Attestation, Challenge, ErrorInformation, Request};
 use std::sync::Arc;
 use strum_macros::EnumString;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::resource::{get_secret_resource, Repository, ResourceDesc};
 use crate::session::{Session, SessionMap, KBS_SESSION_ID};
@@ -143,7 +143,7 @@ pub(crate) async fn attest(
 /// GET /resource/{type}/{tag}
 pub(crate) async fn get_resource(
     request: HttpRequest,
-    repository: web::Data<Arc<dyn Repository + Send + Sync>>,
+    repository: web::Data<Arc<RwLock<dyn Repository + Send + Sync>>>,
     map: web::Data<SessionMap<'_>>,
 ) -> HttpResponse {
     let cookie = match request.cookie(KBS_SESSION_ID) {

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -165,6 +165,13 @@ impl ApiServer {
                     ])
                     .route(web::get().to(http::get_resource)),
                 )
+                .service(
+                    web::resource([
+                        kbs_path!("resource/{repository}/{type}/{tag}"),
+                        kbs_path!("resource/{type}/{tag}"),
+                    ])
+                    .route(web::post().to(http::set_resource)),
+                )
         });
 
         if !self.insecure {

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -163,7 +163,7 @@ impl ApiServer {
                         kbs_path!("resource/{repository}/{type}/{tag}"),
                         kbs_path!("resource/{type}/{tag}"),
                     ])
-                    .route(web::get().to(http::resource)),
+                    .route(web::get().to(http::get_resource)),
                 )
         });
 

--- a/src/api_server/src/lib.rs
+++ b/src/api_server/src/lib.rs
@@ -4,6 +4,8 @@
 
 //! KBS API server
 
+#![allow(clippy::too_many_arguments)]
+
 extern crate actix_web;
 extern crate anyhow;
 extern crate attestation_service;

--- a/src/api_server/src/resource/mod.rs
+++ b/src/api_server/src/resource/mod.rs
@@ -71,7 +71,7 @@ impl RepositoryType {
     }
 }
 
-pub(crate) fn secret_resource(
+pub(crate) async fn secret_resource(
     tee_pub_key: TeePubKey,
     repository: &Arc<dyn Repository + Send + Sync>,
     resource_desc: ResourceDesc,
@@ -82,6 +82,7 @@ pub(crate) fn secret_resource(
 
     let resource_byte = repository
         .read_secret_resource(resource_desc)
+        .await
         .map_err(|e| anyhow!("Read secret resource from repository failed: {:?}", e))?;
 
     let mut rng = rand::thread_rng();

--- a/src/api_server/src/resource/mod.rs
+++ b/src/api_server/src/resource/mod.rs
@@ -30,6 +30,13 @@ const AES_GCM_256_ALGORITHM: &str = "A256GCM";
 pub trait Repository {
     /// Read secret resource from repository.
     async fn read_secret_resource(&self, resource_desc: ResourceDesc) -> Result<Vec<u8>>;
+
+    /// Write secret resource into repository
+    async fn write_secret_resource(
+        &mut self,
+        resource_desc: ResourceDesc,
+        data: &[u8],
+    ) -> Result<()>;
 }
 
 #[derive(Debug, Clone)]

--- a/src/api_server/src/resource/mod.rs
+++ b/src/api_server/src/resource/mod.rs
@@ -78,7 +78,7 @@ impl RepositoryType {
     }
 }
 
-pub(crate) async fn secret_resource(
+pub(crate) async fn get_secret_resource(
     tee_pub_key: TeePubKey,
     repository: &Arc<dyn Repository + Send + Sync>,
     resource_desc: ResourceDesc,

--- a/src/api_server/src/resource/mod.rs
+++ b/src/api_server/src/resource/mod.rs
@@ -26,9 +26,10 @@ const RSA_ALGORITHM: &str = "RSA1_5";
 const AES_GCM_256_ALGORITHM: &str = "A256GCM";
 
 /// Interface of a `Repository`.
+#[async_trait::async_trait]
 pub trait Repository {
     /// Read secret resource from repository.
-    fn read_secret_resource(&self, resource_desc: ResourceDesc) -> Result<Vec<u8>>;
+    async fn read_secret_resource(&self, resource_desc: ResourceDesc) -> Result<Vec<u8>>;
 }
 
 #[derive(Debug, Clone)]

--- a/src/kbs/src/main.rs
+++ b/src/kbs/src/main.rs
@@ -45,6 +45,10 @@ struct Cli {
     /// KBS config file path.
     #[arg(default_value_t = String::default(), short, long)]
     config: String,
+
+    /// User's public key to verify JWT
+    #[arg(long)]
+    user_public_key: PathBuf,
 }
 
 #[tokio::main]
@@ -65,6 +69,7 @@ async fn main() -> Result<()> {
         kbs_config,
         cli.socket,
         cli.private_key,
+        cli.user_public_key,
         cli.certificate,
         cli.insecure_http,
         Arc::new(AttestationService::new()?),

--- a/src/kbs/src/main.rs
+++ b/src/kbs/src/main.rs
@@ -46,9 +46,10 @@ struct Cli {
     #[arg(default_value_t = String::default(), short, long)]
     config: String,
 
-    /// User's public key to verify JWT
+    /// Public key used to authenticate the resource registration endpoint token (JWT).
+    /// Only JWTs signed with the corresponding private keys will be authenticated.
     #[arg(long)]
-    user_public_key: PathBuf,
+    auth_public_key: PathBuf,
 }
 
 #[tokio::main]
@@ -69,7 +70,7 @@ async fn main() -> Result<()> {
         kbs_config,
         cli.socket,
         cli.private_key,
-        cli.user_public_key,
+        cli.auth_public_key,
         cli.certificate,
         cli.insecure_http,
         Arc::new(AttestationService::new()?),


### PR DESCRIPTION
This PR adds the resource registration api. Refer to the implementation of an image registry, use http POST seems a good choice.

However, as confidential resource insertion is different from retrievement, it should ensure the caller is either the owner of the KBS or the owner of the repository. For test, This pr wraps all registration-related code into a feature `unsafe`, meaning this is only for test. 

Close https://github.com/confidential-containers/kbs/pull/30