### PR TITLE
Update Client Tool to adapt KBS resource URI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 [[package]]
 name = "attestation_agent"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-agent#55db1216334ca41775cb9099e39bb1a863704e55"
+source = "git+https://github.com/confidential-containers/attestation-agent#beab1ba98cc40a97b37fe2365b3cdd69b4b72052"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -374,7 +374,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "strum",
- "tdx-attest-rs",
  "url",
  "zeroize",
 ]
@@ -671,8 +670,6 @@ dependencies = [
  "clap 4.1.6",
  "env_logger 0.10.0",
  "log",
- "serde",
- "serde_json",
  "tokio",
 ]
 
@@ -2765,22 +2762,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tdx-attest-rs"
-version = "0.1.0"
-source = "git+https://github.com/intel/SGXDataCenterAttestationPrimitives?rev=85cf8bdd#85cf8bdd393ab273a308be3f41d2f7cc25c0ec0c"
-dependencies = [
- "tdx-attest-sys",
-]
-
-[[package]]
-name = "tdx-attest-sys"
-version = "0.1.0"
-source = "git+https://github.com/intel/SGXDataCenterAttestationPrimitives?rev=85cf8bdd#85cf8bdd393ab273a308be3f41d2f7cc25c0ec0c"
-dependencies = [
- "bindgen",
 ]
 
 [[package]]

--- a/tools/client/Cargo.toml
+++ b/tools/client/Cargo.toml
@@ -11,8 +11,6 @@ anyhow.workspace = true
 api-server.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }
 env_logger.workspace = true
-serde = { version = "1.0", features = ["derive"] }
-serde_json.workspace = true
 log.workspace = true
 tokio.workspace = true
 

--- a/tools/client/README.md
+++ b/tools/client/README.md
@@ -14,8 +14,10 @@ For help:
 Request resource from KBS:
 
 ```shell
-./client --kbs-url http:/127.0.0.1:8080 --resource-path <repository>/<type>/<tag>
+./client --resource-uri kbs://127.0.0.1:8080/<repository>/<type>/<tag>
 ```
+
+Where the format of [KBS Resource URI](https://github.com/confidential-containers/attestation-agent/blob/main/docs/KBS_URI.md) is defined by Attestation Agent.
 
 Make sure this client run inside a real TEE which [Attestation Agent](https://github.com/confidential-containers/attestation-agent) supported (otherwise attestation will failed).
 

--- a/tools/client/src/main.rs
+++ b/tools/client/src/main.rs
@@ -8,27 +8,16 @@ use anyhow::Result;
 use attestation_agent::AttestationAPIs;
 use attestation_agent::AttestationAgent;
 use clap::Parser;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 const CC_KBC_NAME: &str = "cc_kbc";
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    /// KBS URL. e.g: http://127.0.0.1:8080
+    /// KBS Resource URi. e.g: kbs://127.0.0.1:8080/my_repo/resource_type/123abc
+    /// Document: https://github.com/confidential-containers/attestation-agent/blob/main/docs/KBS_URI.md
     #[arg(required = true, long)]
-    kbs_url: String,
-
-    /// Resource path. e.g: "my_repo/resource_type/123abc"
-    #[arg(required = true, short, long)]
-    resource_path: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct ResourceDescription {
-    pub name: String,
-    pub optional: HashMap<String, String>,
+    resource_uri: String,
 }
 
 #[tokio::main]
@@ -36,26 +25,11 @@ async fn main() -> Result<()> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
     let cli = Cli::parse();
-    let resource_path: Vec<&str> = cli.resource_path.split('/').collect();
 
     let mut attestation_agent = AttestationAgent::new();
 
-    let mut resource_desc_map = HashMap::new();
-    resource_desc_map.insert("repository".to_string(), resource_path[0].to_string());
-    resource_desc_map.insert("type".to_string(), resource_path[1].to_string());
-    resource_desc_map.insert("tag".to_string(), resource_path[2].to_string());
-
-    let resource_desc = ResourceDescription {
-        name: String::default(),
-        optional: resource_desc_map,
-    };
-
     let resource_byte = attestation_agent
-        .download_confidential_resource(
-            CC_KBC_NAME,
-            &cli.kbs_url,
-            &serde_json::to_string(&resource_desc)?,
-        )
+        .download_confidential_resource(CC_KBC_NAME, &cli.resource_uri)
         .await?;
 
     println!("Resource: {:?}", &resource_byte);


### PR DESCRIPTION
Updated the Client Tool to use the [KBS resource URI](https://github.com/confidential-containers/attestation-agent/blob/main/docs/KBS_URI.md) format defined by the Attention Agent.