### PR TITLE
api_server: fix kbs-types version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
  "attestation-service",
  "base64 0.13.1",
  "env_logger 0.10.0",
- "kbs-types",
+ "kbs-types 0.1.0 (git+https://github.com/virtee/kbs-types.git?rev=13b9378f)",
  "lazy_static",
  "log",
  "rand",
@@ -321,20 +321,21 @@ dependencies = [
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git#11277c494e631e0758a0ddaa458ff9d7dd5b57b0"
+source = "git+https://github.com/confidential-containers/attestation-service.git?rev=34d0275#34d02756acc9fb76e2dd9f8ee217bae1693dc2a3"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
  "byteorder",
  "cc-measurement",
+ "cfg-if",
  "chrono",
  "clap 3.2.23",
  "env_logger 0.9.3",
  "futures 0.3.26",
  "hex",
  "in-toto",
- "kbs-types",
+ "kbs-types 0.1.0 (git+https://github.com/virtee/kbs-types.git?rev=13b9378f)",
  "lazy_static",
  "log",
  "path-clean",
@@ -365,7 +366,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "ctr",
- "kbs-types",
+ "kbs-types 0.1.0 (git+https://github.com/virtee/kbs-types.git)",
  "log",
  "rand",
  "reqwest",
@@ -1559,6 +1560,15 @@ dependencies = [
  "env_logger 0.10.0",
  "log",
  "tokio",
+]
+
+[[package]]
+name = "kbs-types"
+version = "0.1.0"
+source = "git+https://github.com/virtee/kbs-types.git?rev=13b9378f#13b9378ff675f6de3cd44a1efb41d5b728f8277c"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 api-server = { path = "src/api_server" }
 anyhow = "1.0"
 async-trait = "0.1.31"
-attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git" }
+attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "34d0275" }
 base64 = "0.13.1"
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 env_logger.workspace = true
 lazy_static = "1.4.0"
 log.workspace = true
-kbs-types = { git = "https://github.com/virtee/kbs-types.git" }
+kbs-types = { git = "https://github.com/virtee/kbs-types.git", rev = "13b9378f" }
 rand = "0.8.5"
 rsa = "0.7.2"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
As the underlying attestation-service fixed rev of `kbs-types`, different revs of `kbs-types` will cause the following error
```
   Compiling attestation-service v0.1.0 (https://github.com/confidential-containers/attestation-service.git?rev=34d0275#34d02756)
   Compiling api-server v0.1.0 (/home/kbs/src/api_server)
error[E0308]: mismatched types
   --> src/api_server/src/http.rs:122:13
    |
121 |         .evaluate(
    |          -------- arguments to this function are incorrect
122 |             session.tee(),
    |             ^^^^^^^^^^^^^ expected enum `attestation_service::Tee`, found enum `kbs_types::Tee`
    |
    = note: enum `kbs_types::Tee` and enum `attestation_service::Tee` have similar names, but are actually distinct types
note: enum `kbs_types::Tee` is defined in crate `kbs_types`
   --> /root/.cargo/git/checkouts/kbs-types-8f44a35c40c15de4/13b9378/src/lib.rs:12:1
    |
12  | pub enum Tee {
    | ^^^^^^^^^^^^
note: enum `attestation_service::Tee` is defined in crate `kbs_types`
   --> /root/.cargo/git/checkouts/kbs-types-8f44a35c40c15de4/13b9378/src/lib.rs:12:1
    |
12  | pub enum Tee {
    | ^^^^^^^^^^^^
    = note: perhaps two different versions of crate `kbs_types` are being used?
note: associated function defined here
   --> /root/.cargo/git/checkouts/attestation-service-fed607e36ff88ac9/34d0275/src/lib.rs:91:18
    |
91  |     pub async fn evaluate(
    |                  ^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `api-server` due to previous error
```