### PR TITLE
docker-compose: add default rersources

### DIFF
--- a/data/kbs-storage/default/security-policy/test
+++ b/data/kbs-storage/default/security-policy/test
@@ -1,0 +1,3 @@
+{
+    "default": [{"type": "insecureAcceptAnything"}]
+}

--- a/data/kbs-storage/default/sigstore-config/test
+++ b/data/kbs-storage/default/sigstore-config/test
@@ -1,0 +1,4 @@
+docker:
+    quay.io/kata-containers/confidential-containers:
+        sigstore: file:///etc/containers/quay_verification/signatures
+        sigstore-staging: file:///etc/containers/quay_verification/signatures


### PR DESCRIPTION
when `simple-signing` is enabled, by default the file `default/sigstore-config/test` will be retrieved

when `security_validate`, by default the file
`default/security-policy/test` will be retrieved

Those two default files are for quick start

Fixes: #58