### PR TITLE
Use kbs-types v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,11 +399,7 @@ dependencies = [
 [[package]]
 name = "as-types"
 version = "0.1.0"
-<<<<<<< HEAD
 source = "git+https://github.com/confidential-containers/attestation-service.git?rev=a70c502#a70c5025c6bc896484e5877a41adfe0fe520f9ba"
-=======
-source = "git+https://github.com/mkulke/attestation-service.git?rev=2325a1e#2325a1e778faae3709450d93258c82784603a9fe"
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 dependencies = [
  "kbs-types",
  "serde",
@@ -440,21 +436,13 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.11",
-=======
- "syn 2.0.10",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-<<<<<<< HEAD
 source = "git+https://github.com/confidential-containers/attestation-service.git?rev=a70c502#a70c5025c6bc896484e5877a41adfe0fe520f9ba"
-=======
-source = "git+https://github.com/mkulke/attestation-service.git?rev=2325a1e#2325a1e778faae3709450d93258c82784603a9fe"
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 dependencies = [
  "anyhow",
  "as-types",
@@ -492,11 +480,7 @@ dependencies = [
 [[package]]
 name = "attestation_agent"
 version = "0.1.0"
-<<<<<<< HEAD
 source = "git+https://github.com/confidential-containers/attestation-agent?rev=d7ace56#d7ace56f2f2c861669ab07b50598a3d3c22709af"
-=======
-source = "git+https://github.com/mkulke/attestation-agent?rev=17517d8#17517d857d2d3f511f64b9aa4dc586d0c892e721"
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -783,23 +767,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-<<<<<<< HEAD
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6efb5f0a41b5ef5b50c5da28c07609c20091df0c1fc33d418fa2a7e693c2b624"
 dependencies = [
  "clap_builder",
  "clap_derive 4.2.0",
-=======
-version = "4.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
-dependencies = [
- "bitflags",
- "clap_derive 4.1.12",
- "clap_lex 0.3.3",
- "is-terminal",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
  "once_cell",
 ]
 
@@ -838,11 +811,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.11",
-=======
- "syn 2.0.10",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -867,11 +836,7 @@ dependencies = [
  "anyhow",
  "api-server",
  "attestation_agent",
-<<<<<<< HEAD
  "clap 4.2.0",
-=======
- "clap 4.1.13",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
  "env_logger 0.10.0",
  "log",
  "tokio",
@@ -1103,11 +1068,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
-<<<<<<< HEAD
  "syn 2.0.11",
-=======
- "syn 2.0.10",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -1124,11 +1085,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.11",
-=======
- "syn 2.0.10",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -1965,11 +1922,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "api-server",
-<<<<<<< HEAD
  "clap 4.2.0",
-=======
- "clap 4.1.13",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
  "env_logger 0.10.0",
  "log",
  "tokio",
@@ -2675,7 +2628,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
-<<<<<<< HEAD
 ]
 
 [[package]]
@@ -2685,8 +2637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
-=======
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -2964,11 +2914,7 @@ checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.11",
-=======
- "syn 2.0.10",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -3178,15 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-<<<<<<< HEAD
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
-=======
-version = "2.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3244,11 +3184,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.11",
-=======
- "syn 2.0.10",
->>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -32,7 +32,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.3",
  "base64 0.21.0",
- "bitflags 1.3.2",
+ "bitflags",
  "brotli",
  "bytes",
  "bytestring",
@@ -316,6 +316,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-wincon",
+ "concolor-override",
+ "concolor-query",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,7 +376,7 @@ dependencies = [
  "cfg-if",
  "env_logger 0.10.0",
  "jwt-simple",
- "kbs-types 0.1.0",
+ "kbs-types",
  "lazy_static",
  "log",
  "prost",
@@ -359,9 +399,9 @@ dependencies = [
 [[package]]
 name = "as-types"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git?rev=0f7a70e#0f7a70e98fc14890f2842dc66222b55ff28e1d99"
+source = "git+https://github.com/confidential-containers/attestation-service.git?rev=a70c502#a70c5025c6bc896484e5877a41adfe0fe520f9ba"
 dependencies = [
- "kbs-types 0.1.0",
+ "kbs-types",
  "serde",
  "serde_json",
 ]
@@ -390,19 +430,19 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git?rev=0f7a70e#0f7a70e98fc14890f2842dc66222b55ff28e1d99"
+source = "git+https://github.com/confidential-containers/attestation-service.git?rev=a70c502#a70c5025c6bc896484e5877a41adfe0fe520f9ba"
 dependencies = [
  "anyhow",
  "as-types",
@@ -418,7 +458,7 @@ dependencies = [
  "hex",
  "in-toto",
  "intel-tee-quote-verification-rs",
- "kbs-types 0.1.0",
+ "kbs-types",
  "lazy_static",
  "log",
  "path-clean",
@@ -440,14 +480,14 @@ dependencies = [
 [[package]]
 name = "attestation_agent"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-agent?rev=1e638c7#1e638c7854a82dceb6a41ae153ac381e63d7933d"
+source = "git+https://github.com/confidential-containers/attestation-agent?rev=d7ace56#d7ace56f2f2c861669ab07b50598a3d3c22709af"
 dependencies = [
  "aes-gcm",
  "anyhow",
  "async-trait",
  "base64 0.13.1",
  "ctr",
- "kbs-types 0.2.0",
+ "kbs-types",
  "log",
  "rand",
  "reqwest",
@@ -485,7 +525,7 @@ checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -552,7 +592,7 @@ version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "clap 3.2.23",
@@ -580,12 +620,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "block-buffer"
@@ -656,7 +690,7 @@ dependencies = [
 [[package]]
 name = "cc-measurement"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/td-shim#9e1cf6c1cb962030ba42ee66642e7ec162806326"
+source = "git+https://github.com/confidential-containers/td-shim#dbce7bbe36ab6a0538588db2ba29553b63c9d287"
 dependencies = [
  "sha2",
  "zerocopy",
@@ -721,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags 1.3.2",
+ "bitflags",
  "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
@@ -733,17 +767,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.12"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e21918af71fb4bcd813230cf549e33d14f73d0326b932b630ce2930332b131"
+checksum = "6efb5f0a41b5ef5b50c5da28c07609c20091df0c1fc33d418fa2a7e693c2b624"
 dependencies = [
- "bitflags 2.0.2",
- "clap_derive 4.1.12",
- "clap_lex 0.3.3",
- "is-terminal",
+ "clap_builder",
+ "clap_derive 4.2.0",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671fcaa5debda4b9a84aa7fde49c907c8986c0e6ab927e04217c9cb74e7c8bc9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
@@ -761,14 +804,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.12"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -782,12 +825,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "client"
@@ -796,7 +836,7 @@ dependencies = [
  "anyhow",
  "api-server",
  "attestation_agent",
- "clap 4.1.12",
+ "clap 4.2.0",
  "env_logger 0.10.0",
  "log",
  "tokio",
@@ -822,6 +862,21 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "concolor-override"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -903,9 +958,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -991,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1003,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1013,24 +1068,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.8",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -1182,13 +1237,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1368,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1403,7 +1458,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "libc",
  "libgit2-sys",
  "log",
@@ -1703,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1755,25 +1810,25 @@ checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1867,7 +1922,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "api-server",
- "clap 4.1.12",
+ "clap 4.2.0",
  "env_logger 0.10.0",
  "log",
  "tokio",
@@ -1875,17 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.1.0"
-source = "git+https://github.com/virtee/kbs-types.git?rev=13b9378f#13b9378ff675f6de3cd44a1efb41d5b728f8277c"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "kbs-types"
 version = "0.2.0"
-source = "git+https://github.com/virtee/kbs-types#a25284eb9eb221bba752a7d250f502a2b8e7561b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54492d453c6c287fd130112e58a7588ddb3f28b4dea44daf32000f99e13077"
 dependencies = [
  "serde",
  "serde_json",
@@ -1969,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
 
 [[package]]
 name = "local-channel"
@@ -2067,7 +2114,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2225,7 +2272,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
@@ -2238,9 +2285,9 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2458,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -2580,14 +2627,23 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2602,9 +2658,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -2725,16 +2781,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2843,29 +2899,29 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa 1.0.6",
  "ryu",
@@ -3068,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3085,15 +3141,15 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3128,7 +3184,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -3188,14 +3244,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -3203,7 +3258,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3218,13 +3273,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.11",
 ]
 
 [[package]]
@@ -3406,9 +3461,9 @@ dependencies = [
 
 [[package]]
 name = "tzdb"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b882d864be6a5d7c3c916719944458b1e03c85f86dbc825ec98155117c4408"
+checksum = "c06bbefdf1c2f9bb910958da9e23a78ad1bd45bf1bae48095f0fc343e3798a2f"
 dependencies = [
  "iana-time-zone",
  "tz-rs",
@@ -3473,6 +3528,12 @@ dependencies = [
  "idna 0.3.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -3676,21 +3737,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -3787,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,11 @@ dependencies = [
 [[package]]
 name = "as-types"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/confidential-containers/attestation-service.git?rev=a70c502#a70c5025c6bc896484e5877a41adfe0fe520f9ba"
+=======
+source = "git+https://github.com/mkulke/attestation-service.git?rev=2325a1e#2325a1e778faae3709450d93258c82784603a9fe"
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 dependencies = [
  "kbs-types",
  "serde",
@@ -436,13 +440,21 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.11",
+=======
+ "syn 2.0.10",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/confidential-containers/attestation-service.git?rev=a70c502#a70c5025c6bc896484e5877a41adfe0fe520f9ba"
+=======
+source = "git+https://github.com/mkulke/attestation-service.git?rev=2325a1e#2325a1e778faae3709450d93258c82784603a9fe"
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 dependencies = [
  "anyhow",
  "as-types",
@@ -480,7 +492,11 @@ dependencies = [
 [[package]]
 name = "attestation_agent"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/confidential-containers/attestation-agent?rev=d7ace56#d7ace56f2f2c861669ab07b50598a3d3c22709af"
+=======
+source = "git+https://github.com/mkulke/attestation-agent?rev=17517d8#17517d857d2d3f511f64b9aa4dc586d0c892e721"
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -767,12 +783,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
+<<<<<<< HEAD
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6efb5f0a41b5ef5b50c5da28c07609c20091df0c1fc33d418fa2a7e693c2b624"
 dependencies = [
  "clap_builder",
  "clap_derive 4.2.0",
+=======
+version = "4.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
+dependencies = [
+ "bitflags",
+ "clap_derive 4.1.12",
+ "clap_lex 0.3.3",
+ "is-terminal",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
  "once_cell",
 ]
 
@@ -811,7 +838,11 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.11",
+=======
+ "syn 2.0.10",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -836,7 +867,11 @@ dependencies = [
  "anyhow",
  "api-server",
  "attestation_agent",
+<<<<<<< HEAD
  "clap 4.2.0",
+=======
+ "clap 4.1.13",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
  "env_logger 0.10.0",
  "log",
  "tokio",
@@ -1068,7 +1103,11 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
+<<<<<<< HEAD
  "syn 2.0.11",
+=======
+ "syn 2.0.10",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -1085,7 +1124,11 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.11",
+=======
+ "syn 2.0.10",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -1922,7 +1965,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "api-server",
+<<<<<<< HEAD
  "clap 4.2.0",
+=======
+ "clap 4.1.13",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
  "env_logger 0.10.0",
  "log",
  "tokio",
@@ -2628,6 +2675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+<<<<<<< HEAD
 ]
 
 [[package]]
@@ -2637,6 +2685,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags",
+=======
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -2914,7 +2964,11 @@ checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.11",
+=======
+ "syn 2.0.10",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]
@@ -3124,9 +3178,15 @@ dependencies = [
 
 [[package]]
 name = "syn"
+<<<<<<< HEAD
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+=======
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3184,7 +3244,11 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.11",
+=======
+ "syn 2.0.10",
+>>>>>>> Bump AA/AS deps temporarily to version w/ updated kbs-types
 ]
 
 [[package]]

--- a/docs/kbs.yaml
+++ b/docs/kbs.yaml
@@ -326,21 +326,21 @@ components:
 
     PublicKey:
       required:
-        - kty
         - alg
-        - k
+        - k-mod
+        - k-exp
       properties:
-        kty:
-          type: string
-          description: Key type
         alg:
           type: string
           description: Key Algorithm
-        k:
+        k-mod:
           type: string
-          description: Key data
+          description: Key modulus
+        k-exp:
+          type: string
+          description: Key exponent
       description: >-
-        A JSON Web Key (https://www.rfc-editor.org/rfc/rfc7517) formatted object.
+        A JSON Web Key (https://www.rfc-editor.org/rfc/rfc7517) formatted RSA Public Key.
 
     ErrorInformation:
       required:

--- a/docs/kbs_attestation_protocol.md
+++ b/docs/kbs_attestation_protocol.md
@@ -247,11 +247,14 @@ The [`Attestation`](#attestation) and the [Token Resource](#token-resource)
 `tee-pubkey` field contains a public key from a HW-TEE generated asymmetric
 key pair.
 
+This field follows the [JSON Web Key](https://www.rfc-editor.org/rfc/rfc7517)
+format.
+
 ``` json
 {
     "alg": "$key_algorithm",
-    "k_mod": "$pubkey modulus",
-    "k_exp": "$pubkey exponent"
+    "k-mod": "$pubkey modulus",
+    "k-exp": "$pubkey exponent"
 }
 ```
 

--- a/docs/kbs_attestation_protocol.md
+++ b/docs/kbs_attestation_protocol.md
@@ -246,14 +246,12 @@ in `alg`.
 The [`Attestation`](#attestation) and the [Token Resource](#token-resource)
 `tee-pubkey` field contains a public key from a HW-TEE generated asymmetric
 key pair.
-This field follows the [JSON Web Key](https://www.rfc-editor.org/rfc/rfc7517)
-format:
 
 ``` json
 {
-    "kty": "$key_type",
     "alg": "$key_algorithm",
-    "k": "public_key"
+    "k_mod": "$pubkey modulus",
+    "k_exp": "$pubkey exponent"
 }
 ```
 

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -18,8 +18,8 @@ actix-web-httpauth = "0.8.0"
 aes-gcm = "0.10.1"
 anyhow.workspace = true
 async-trait.workspace = true
-as-types = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "0f7a70e"}
-attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, rev = "0f7a70e", optional = true}
+as-types = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "a70c502"}
+attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, rev = "a70c502", optional = true}
 base64.workspace = true
 cfg-if = "1.0.0"
 env_logger.workspace = true
@@ -40,7 +40,6 @@ strum_macros = "0.24.1"
 tokio.workspace = true
 tonic = { version = "0.8", optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
-num-traits = "0.2.15"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -24,7 +24,7 @@ base64.workspace = true
 cfg-if = "1.0.0"
 env_logger.workspace = true
 jwt-simple = "0.11.4"
-kbs-types = { git = "https://github.com/virtee/kbs-types.git", rev = "13b9378f" }
+kbs-types = "0.2"
 lazy_static = "1.4.0"
 log.workspace = true
 prost = { version = "0.11", optional = true }
@@ -40,6 +40,7 @@ strum_macros = "0.24.1"
 tokio.workspace = true
 tonic = { version = "0.8", optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+num-traits = "0.2.15"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/src/api_server/src/resource/mod.rs
+++ b/src/api_server/src/resource/mod.rs
@@ -10,7 +10,6 @@ use aes_gcm::{
 use anyhow::{anyhow, Result};
 use kbs_types::{Response, TeePubKey};
 use local_fs::{LocalFs, LocalFsRepoDesc};
-use num_traits::Num;
 use rsa::{BigUint, PaddingScheme, PublicKey, RsaPublicKey};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -105,10 +104,10 @@ pub(crate) async fn get_secret_resource(
         .encrypt(nonce, resource_byte.as_slice())
         .map_err(|e| anyhow!("AES encrypt Resource payload failed: {:?}", e))?;
 
-    let n = BigUint::from_str_radix(&tee_pub_key.k_mod, 10)
-        .map_err(|e| anyhow!("Parse TEE pubkey modulus failed: {:?}", e))?;
-    let e = BigUint::from_str_radix(&tee_pub_key.k_exp, 10)
-        .map_err(|e| anyhow!("Parse TEE pubkey exponent failed: {:?}", e))?;
+    let k_mod = base64::decode(&tee_pub_key.k_mod)?;
+    let n = BigUint::from_bytes_be(&k_mod);
+    let k_exp = base64::decode(&tee_pub_key.k_exp)?;
+    let e = BigUint::from_bytes_be(&k_exp);
 
     let rsa_pub_key = RsaPublicKey::new(n, e)
         .map_err(|e| anyhow!("Building RSA key from modulus and exponent failed: {:?}", e))?;

--- a/tools/attest.json
+++ b/tools/attest.json
@@ -1,8 +1,8 @@
 {
-    "tee-pubkey": {
-	"kty": "key_type",
-	"alg": "algorithm",
-	"k": "my_key"
-    },
-    "tee-evidence": "my_evidence"
+  "tee-pubkey": {
+    "alg": "algorithm",
+    "k-mod": "my_modulus",
+    "k-exp": "my_exponent"
+  },
+  "tee-evidence": "my_evidence"
 }

--- a/tools/client/Cargo.toml
+++ b/tools/client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent", rev = "1e638c7" }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent", rev = "d7ace56" }
 anyhow.workspace = true
 api-server.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }


### PR DESCRIPTION
Similar to [this PR](https://github.com/confidential-containers/attestation-agent/pull/170) on attestation-agent, we need to adjust `TeePubKey` handling to reflect the updated struct on virtee/kbs-types. The fix needs to be coupled with the respective PRs:

* [ ] https://github.com/confidential-containers/attestation-agent/pull/170
* [ ] https://github.com/confidential-containers/attestation-service/pull/78

Note: This should only be merged once the AA/AS fixes are merged. The last commit is for testing the build, using git revisions pointing to the other 2 PRs.

fixes #60 