### PR TITLE
Add openssl support for s390x

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,4 +15,5 @@ jobs:
     - name: Build Container Image
       run: |
         DOCKER_BUILDKIT=1 docker build -t kbs:native-as . -f docker/Dockerfile; \
+        DOCKER_BUILDKIT=1 docker build -t kbs:native-as-openssl --build-arg KBS_FEATURES=native-as,openssl . -f docker/Dockerfile; \
         DOCKER_BUILDKIT=1 docker build -t kbs:grpc-as . -f docker/Dockerfile.grpc-as

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,10 @@ jobs:
 
     - name: Build
       run: make kbs
-    
+
+    - name: build KBS with openssl
+      run: make kbs-native-as-openssl
+
     - name: build KBS with remote AS mode
       run: make kbs-grpc-as
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,9 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "log",
+ "openssl",
  "pin-project-lite",
+ "tokio-openssl",
  "tokio-rustls",
  "tokio-util",
  "webpki-roots",
@@ -379,6 +381,7 @@ dependencies = [
  "kbs-types",
  "lazy_static",
  "log",
+ "openssl",
  "prost",
  "rand",
  "rsa 0.7.2",
@@ -1298,6 +1301,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2229,45 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -3280,6 +3337,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.11",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+dependencies = [
+ "futures-util",
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,27 @@ kbs:
 
 .PHONY: kbs-native-as
 kbs-native-as:
-	cargo build --no-default-features --features native-as
+	cargo build --no-default-features --features native-as,rustls
 
 .PHONY: kbs-grpc-as
 kbs-grpc-as:
-	cargo build --no-default-features --features grpc-as
+	cargo build --no-default-features --features grpc-as,rustls
 
 .PHONY: kbs-native-as-no-verifier
 kbs-native-as-no-verifier:
-	cargo build --no-default-features --features native-as-no-verifier
+	cargo build --no-default-features --features native-as-no-verifier,rustls
+
+.PHONY: kbs-native-as-openssl
+kbs-native-as-openssl:
+	cargo build --no-default-features --features native-as,openssl
+
+.PHONY: kbs-grpc-as-openssl
+kbs-grpc-as-openssl:
+	cargo build --no-default-features --features grpc-as,openssl
+
+.PHONY: kbs-native-as-no-verifier-openssl
+kbs-native-as-no-verifier-openssl:
+	cargo build --no-default-features --features native-as-no-verifier,openssl
 
 .PHONY: check
 check:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update
 RUN apt-get install -y libtdx-attest-dev libsgx-dcap-quote-verify-dev
 
 # Build and Instll KBS
-RUN cargo install --path src/kbs
+ARG KBS_FEATURES=native-as,rustls
+RUN cargo install --path src/kbs --no-default-features --features ${KBS_FEATURES}
 
 
 FROM debian:stable-slim

--- a/docker/Dockerfile.grpc-as
+++ b/docker/Dockerfile.grpc-as
@@ -6,7 +6,7 @@ COPY . .
 RUN apt-get update && apt install -y protobuf-compiler
 
 # Build and Instll KBS
-RUN cargo install --path src/kbs --no-default-features --features grpc-as
+RUN cargo install --path src/kbs --no-default-features --features grpc-as,rustls
 
 
 FROM ubuntu:22.04

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -7,19 +7,21 @@ documentation.workspace = true
 edition.workspace = true
 
 [features]
-default = ["native-as"]
+default = ["native-as", "rustls"]
 native-as = ["attestation-service/default"]
 native-as-no-verifier = ["attestation-service/rvps-native"]
 grpc-as = ["tonic", "tonic-build", "prost"]
+rustls = ["actix-web/rustls", "dep:rustls", "dep:rustls-pemfile"]
+openssl = ["actix-web/openssl", "dep:openssl"]
 
 [dependencies]
-actix-web = { version = "4", features = ["rustls"] }
+actix-web = "4"
 actix-web-httpauth = "0.8.0"
 aes-gcm = "0.10.1"
 anyhow.workspace = true
 async-trait.workspace = true
-as-types = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "57c55db"}
-attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, rev = "57c55db", optional = true}
+as-types = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "eb9c069"}
+attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, rev = "eb9c069", optional = true}
 base64.workspace = true
 cfg-if = "1.0.0"
 env_logger.workspace = true
@@ -30,8 +32,8 @@ log.workspace = true
 prost = { version = "0.11", optional = true }
 rand = "0.8.5"
 rsa = "0.7.2"
-rustls = "0.20.8"
-rustls-pemfile = "1.0.2"
+rustls = { version = "0.20.8", optional = true }
+rustls-pemfile = { version = "1.0.2", optional = true }
 semver = "1.0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json.workspace = true
@@ -40,6 +42,7 @@ strum_macros = "0.24.1"
 tokio.workspace = true
 tonic = { version = "0.8", optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+openssl = { version = "0.10.46", optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/src/kbs/Cargo.toml
+++ b/src/kbs/Cargo.toml
@@ -7,10 +7,12 @@ documentation.workspace = true
 edition.workspace = true
 
 [features]
-default = ["native-as"]
+default = ["native-as", "rustls"]
 native-as = ["api-server/native-as"]
 native-as-no-verifier = ["api-server/native-as-no-verifier"]
 grpc-as = ["api-server/grpc-as"]
+rustls = ["api-server/rustls"]
+openssl = ["api-server/openssl"]
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
This PR provides the openssl option for the KBS https server because rustls does not work on s390x.

For selection of rustls and openssl, `#[cfg(not(target_arch = "s390x"))]` and `#[cfg(arget_arch = "s390x")]` are used. One curious thing is that `[target.'cfg(not(target_arch = "s390x"))'.dependencies]` does not work in src/api_server/Cargo.toml. So, we still need to comment out the dependencies manually to build kbs on s390x.

I appreciate if anyone give an advice to fix the above issue.
