### PR TITLE
Fix revision for attestation-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "attestation_agent"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-agent#42a8756be6c21cce57c9bc6ff2e56d17ced650aa"
+source = "git+https://github.com/confidential-containers/attestation-agent?rev=1e638c7#1e638c7854a82dceb6a41ae153ac381e63d7933d"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/tools/client/Cargo.toml
+++ b/tools/client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent" }
+attestation_agent = { git = "https://github.com/confidential-containers/attestation-agent", rev = "1e638c7" }
 anyhow.workspace = true
 api-server.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }


### PR DESCRIPTION
At the moment the kbs test client is referencing HEAD of attestation-agent. Due to changes in the kbs-types data structures attestation service and kbs will have incompatible protocol payload. That's why we need to fix the revision, so we can iterate on the leaf packages (attestation agent/service), w/o breaking kbs.