### PR TITLE
api_server: get rid of in-toto for native-as

### DIFF
--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 [features]
 default = ["native-as"]
 native-as = ["attestation-service/default"]
-native-as-no-verifier = ["attestation-service/in-toto", "attestation-service/rvps-native"]
+native-as-no-verifier = ["attestation-service/rvps-native"]
 grpc-as = ["tonic", "tonic-build", "prost"]
 
 [dependencies]


### PR DESCRIPTION
Fixes: #67

Hi @tnakaike This PR might help you to delete `with-in-toto` and `without-in-toto` conditions