### PR TITLE
docker-compose: reach a stable version for v0.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./config/kbs-config.json:/etc/kbs-config.json
 
   as:
-    image: quay.io/confidential-containers/attestation-service:v0.5.0-tdx-rc1
+    image: quay.io/confidential-containers/attestation-service:v0.5.0-tdx-rc2
     ports:
     - "50004:50004"
     restart: always
@@ -51,7 +51,7 @@ services:
       - ./data/reference-values:/opt/confidential-containers/attestation-service/reference_values:rw
 
   keyprovider:
-    image: quay.io/confidential-containers/coco-keyprovider:v0.5.0-rc3
+    image: quay.io/confidential-containers/coco-keyprovider:v0.5.0-rc7
     restart: always
     ports:
       - "50000:50000"


### PR DESCRIPTION
**Please do not merge this PR until v0.5.0 release!!!!!!**

This PR helps to give fixed versions for componants for KBS cluster.

Now they are all `rc-` versions, when the v0.5.0 is released, we will rebuild all the images and make a stable `v0.5.0` version to replace all the `rc-` versions.

cc @fidencio 