### PR TITLE
ci: release for kbs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Cut Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      -
+        name: Build and push kbs (gRPC-AS)
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./docker/Dockerfile.grpc-as
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/confidential-containers/key-broker-service:${{ github.ref_name }}, ghcr.io/confidential-containers/key-broker-service:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # build:
     #   context: .
     #   dockerfile: ./docker/Dockerfile.grpc-as
-    image: quay.io/confidential-containers/key-broker-service:v0.5.0-rc4
+    image: ghcr.io/confidential-containers/key-broker-service:latest
     command: [
         "/usr/local/bin/kbs",
         "--socket",
@@ -24,7 +24,7 @@ services:
       - ./config/kbs-config.json:/etc/kbs-config.json
 
   as:
-    image: quay.io/confidential-containers/attestation-service:v0.5.0-tdx-rc1
+    image: ghcr.io/confidential-containers/attestation-service:latest
     ports:
     - "50004:50004"
     restart: always
@@ -43,7 +43,7 @@ services:
     ]
 
   rvps:
-    image: quay.io/confidential-containers/reference-value-provider-service:v0.5.0-rc0
+    image: ghcr.io/confidential-containers/reference-value-provider-service:latest
     restart: always # keep the server running
     ports:
       - "50003:50003"
@@ -51,7 +51,7 @@ services:
       - ./data/reference-values:/opt/confidential-containers/attestation-service/reference_values:rw
 
   keyprovider:
-    image: quay.io/confidential-containers/coco-keyprovider:v0.5.0-rc3
+    image: ghcr.io/confidential-containers/coco-keyprovider:latest
     restart: always
     ports:
       - "50000:50000"

--- a/docker/Dockerfile.grpc-as
+++ b/docker/Dockerfile.grpc-as
@@ -11,4 +11,6 @@ RUN cargo install --path src/kbs --no-default-features --features grpc-as,rustls
 
 FROM ubuntu:22.04
 
+LABEL org.opencontainers.image.source="https://github.com/confidential-containers/kbs"
+
 COPY --from=builder /usr/local/cargo/bin/kbs /usr/local/bin/kbs


### PR DESCRIPTION
This github action should be triggered manually to build a kbs image and publish to ghcr.io