### PR TITLE
chore: bump attestation-service and as-types to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "as-types"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git?rev=57c55db#57c55db82ed2bd11b60703a687a1eeeeb015f147"
+source = "git+https://github.com/confidential-containers/attestation-service.git?rev=v0.5.0#3e0fe2d702a9dcdc273b2c392072ad1103106eb7"
 dependencies = [
  "kbs-types",
  "serde",
@@ -445,18 +445,18 @@ dependencies = [
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git?rev=57c55db#57c55db82ed2bd11b60703a687a1eeeeb015f147"
+source = "git+https://github.com/confidential-containers/attestation-service.git?rev=v0.5.0#3e0fe2d702a9dcdc273b2c392072ad1103106eb7"
 dependencies = [
  "anyhow",
  "as-types",
  "async-trait",
  "base64 0.13.1",
  "byteorder",
- "cc-measurement",
  "cfg-if",
  "chrono",
  "clap 3.2.23",
  "env_logger 0.9.3",
+ "eventlog-rs",
  "futures 0.3.27",
  "hex",
  "in-toto",
@@ -688,15 +688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
-]
-
-[[package]]
-name = "cc-measurement"
-version = "0.1.0"
-source = "git+https://github.com/confidential-containers/td-shim#dbce7bbe36ab6a0538588db2ba29553b63c9d287"
-dependencies = [
- "sha2",
- "zerocopy",
 ]
 
 [[package]]
@@ -1214,6 +1205,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
@@ -1257,6 +1261,21 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eventlog-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe64038aed86ee4ab679f2d90dc6d921abcf328853179fb42a050cc4be03174"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "env_logger 0.8.4",
+ "hex",
+ "lazy_static",
+ "log",
+ "sha2",
 ]
 
 [[package]]
@@ -3877,27 +3896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -20,8 +20,8 @@ actix-web-httpauth = "0.8.0"
 aes-gcm = "0.10.1"
 anyhow.workspace = true
 async-trait.workspace = true
-as-types = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "eb9c069"}
-attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, rev = "eb9c069", optional = true}
+as-types = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "v0.5.0"}
+attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, rev = "v0.5.0", optional = true}
 base64.workspace = true
 cfg-if = "1.0.0"
 env_logger.workspace = true


### PR DESCRIPTION
Hey @wainersm Could you help to review this?