### PR TITLE
Test data: fix security policy

### DIFF
--- a/data/kbs-storage/default/security-policy/test
+++ b/data/kbs-storage/default/security-policy/test
@@ -1,3 +1,4 @@
 {
-    "default": [{"type": "insecureAcceptAnything"}]
+    "default": [{"type": "insecureAcceptAnything"}],
+    "transports": {}
 }


### PR DESCRIPTION
fix the error
```
time="2023-05-03T22:58:25.218213507-04:00" level=debug msg="reading guest console" console-protocol=unix console-url=/run/vc/vm/d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd/console.sock name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=virtcontainers subsystem=sandbox vmconsole="{\"msg\":\"cid d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd eid d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd waiting for exit signal\",\"level\":\"INFO\",\"ts\":\"2023-05-04T02:58:24.572762025Z\",\"name\":\"kata-agent\",\"source\":\"agent\",\"version\":\"0.1.0\",\"pid\":\"119\",\"subsystem\":\"rpc\"}"
INFO[2023-05-03T22:58:25.236465810-04:00] PullImage "[ghcr.io/ray-valdez/busybox:encrypted](http://ghcr.io/ray-valdez/busybox:encrypted)"
DEBU[2023-05-03T22:58:25.236593146-04:00] cc service pull image, req: &PullImageRequest{Image:&ImageSpec{Image:ghcr.io/ray-valdez/busybox:encrypted,Annotations:map[string]string{},},Auth:nil,SandboxConfig:&PodSandboxConfig{Metadata:&PodSandboxMetadata{Name:nginx-sandbox,Uid:f000ae68-4273-444b-94b9-d6dbd7485bc7,Namespace:default,Attempt:1,},Hostname:,LogDirectory:,DnsConfig:nil,PortMappings:[]*PortMapping{},Labels:map[string]string{},Annotations:map[string]string{},Linux:&LinuxPodSandboxConfig{CgroupParent:,SecurityContext:nil,Sysctls:map[string]string{},Overhead:nil,Resources:nil,},Windows:nil,},}
INFO[2023-05-03T22:58:25.236626916-04:00] TaskManager get ImageService succeed.         id=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd
time="2023-05-03T22:58:25.23671975-04:00" level=debug msg="PullImage() start" image="[ghcr.io/ray-valdez/busybox:encrypted](http://ghcr.io/ray-valdez/busybox:encrypted)" name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=containerd-kata-shim-v2
time="2023-05-03T22:58:25.236753769-04:00" level=debug msg="Making image pull request" image="[ghcr.io/ray-valdez/busybox:encrypted](http://ghcr.io/ray-valdez/busybox:encrypted)" name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=containerd-kata-shim-v2
time="2023-05-03T22:58:25.252891677-04:00" level=info msg="kata management inited" name=containerd-shim-v2 source=containerd-kata-shim-v2 subsystem=shim-management
time="2023-05-03T22:58:25.304348435-04:00" level=debug msg="reading guest console" console-protocol=unix console-url=/run/vc/vm/d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd/console.sock name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=virtcontainers subsystem=sandbox vmconsole="{\"msg\":\"image_client.config.auth set to: true\",\"level\":\"INFO\",\"ts\":\"2023-05-04T02:58:24.592480265Z\",\"source\":\"agent\",\"name\":\"kata-agent\",\"pid\":\"119\",\"subsystem\":\"rpc\",\"version\":\"0.1.0\"}"
time="2023-05-03T22:58:25.304416221-04:00" level=debug msg="reading guest console" console-protocol=unix console-url=/run/vc/vm/d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd/console.sock name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=virtcontainers subsystem=sandbox vmconsole="{\"msg\":\"enable_signature_verification set to: true\",\"level\":\"INFO\",\"ts\":\"2023-05-04T02:58:24.592508356Z\",\"version\":\"0.1.0\",\"pid\":\"119\",\"subsystem\":\"rpc\",\"source\":\"agent\",\"name\":\"kata-agent\"}"
time="2023-05-03T22:58:25.30444618-04:00" level=debug msg="reading guest console" console-protocol=unix console-url=/run/vc/vm/d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd/console.sock name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=virtcontainers subsystem=sandbox vmconsole="{\"msg\":\"pull image \\\"busybox_encrypted_0\\\", bundle path \\\"/run/kata-containers/busybox_encrypted_0\\\"\",\"level\":\"INFO\",\"ts\":\"2023-05-04T02:58:24.5925394Z\",\"name\":\"kata-agent\",\"source\":\"agent\",\"subsystem\":\"rpc\",\"pid\":\"119\",\"version\":\"0.1.0\"}"
time="2023-05-03T22:58:25.519984642-04:00" level=debug msg="reading guest console" console-protocol=unix console-url=/run/vc/vm/d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd/console.sock name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=virtcontainers subsystem=sandbox vmconsole="\x1b[0m\x1b[38;5;8m[\x1b[0m2023-05-04T02:58:24Z \x1b[0m\x1b[1m\x1b[31mERROR\x1b[0m attestation_agent::rpc::getresource::ttrpc\x1b[0m\x1b[38;5;8m]\x1b[0m Call AA-KBC to get resource failed: KBS Server Internal Failed, Response: \"Get Resource failed: Read secret resource from repository failed: read resource from local fs\\n\\nCaused by:\\n    No such file or directory (os error 2)\""
time="2023-05-03T22:58:25.889181196-04:00" level=debug msg="reading guest console" console-protocol=unix console-url=/run/vc/vm/d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd/console.sock name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=virtcontainers subsystem=sandbox vmconsole="{\"msg\":\"pull and unpack image \\\"[ghcr.io/ray-valdez/busybox:encrypted](http://ghcr.io/ray-valdez/busybox:encrypted)\\\", cid: \\\"busybox_encrypted_0\\\", with image-rs failed with \\\"Security validate failed: missing field `transports` at line 3 column 1\\\". \",\"level\":\"ERRO\",\"ts\":\"2023-05-04T02:58:25.243756849Z\",\"version\":\"0.1.0\",\"source\":\"agent\",\"subsystem\":\"rpc\",\"name\":\"kata-agent\",\"pid\":\"119\"}"
time="2023-05-03T22:58:25.889280012-04:00" level=error msg="agent pull image err. rpc error: code = Internal desc = Security validate failed: missing field `transports` at line 3 column 1" name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=virtcontainers subsystem=kata_agent
time="2023-05-03T22:58:25.889325136-04:00" level=error msg="kata runtime PullImage err. rpc error: code = Internal desc = Security validate failed: missing field `transports` at line 3 column 1" name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=containerd-kata-shim-v2
time="2023-05-03T22:58:25.889348278-04:00" level=debug msg="PullImage() end" image="[ghcr.io/ray-valdez/busybox:encrypted](http://ghcr.io/ray-valdez/busybox:encrypted)" name=containerd-shim-v2 pid=3489388 sandbox=d1a0c80eab5ac6607d6cd58458efb16f38db25601234b88dbd1bce870e0546bd source=containerd-kata-shim-v2
ERRO[2023-05-03T22:58:25.889620697-04:00] PullImage "[ghcr.io/ray-valdez/busybox:encrypted](http://ghcr.io/ray-valdez/busybox:encrypted)" failed  error="rpc error: code = Internal desc = Security validate failed: missing field `transports` at line 3 column 1"
```