### PR TITLE
Add e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,9 @@ jobs:
   e2e-test:
     strategy:
       matrix:
-        tee: [ "sample", "az-snp-vtpm" ]
+        tee:
+        - sample
+        # - az-snp-vtpm
 
     runs-on: ${{ ((matrix.tee == 'az-snp-vtpm') && fromJSON('["self-hosted","azure-cvm"]')) || 'ubuntu-22.04' }}
 
@@ -29,24 +31,6 @@ jobs:
       with:
         go-version: stable
 
-    - name: Install dependencies
-      env:
-        SGX_URL: https://download.01.org/intel-sgx/sgx_repo/ubuntu
-      run: |
-        curl -L "${SGX_URL}/intel-sgx-deb.key" | sudo apt-key add -
-        echo "deb [arch=amd64] ${SGX_URL} jammy main" \
-          | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-        sudo apt-get update
-        sudo apt-get install -y \
-          build-essential \
-          clang \
-          libsgx-dcap-quote-verify-dev \
-          libtdx-attest-dev \
-          libtss2-dev \
-          openssl \
-          pkg-config \
-          protobuf-compiler
-
     - name: Set up rust build cache
       uses: actions/cache@v3
       continue-on-error: false
@@ -57,37 +41,18 @@ jobs:
           target/
         key: rust-${{ hashFiles('./Cargo.lock') }}
 
-    - name: Build kbs
-      run: cargo b -p kbs --release
+    - name: Install dependencies
+      working-directory: test
+      run: sudo make install-dependencies
 
-    - name: Start kbs
-      run: | 
-        openssl genpkey -algorithm ed25519 > kbs.key
-        openssl pkey -in kbs.key -pubout -out kbs.pem
-        sudo ./target/release/kbs \
-          --socket 127.0.0.1:8080 \
-          --insecure-http \
-          --auth-public-key ./kbs.pem &
-
-    - name: Add secret resource to kbs repository
-      env:
-        REPO_PATH: /opt/confidential-containers/kbs/repository
-      run: |
-        sudo mkdir -p "${REPO_PATH}/one/two"
-        openssl rand 16 > a_secret
-        sudo cp a_secret "${REPO_PATH}/one/two/three"
-
-    - name: Build client
-      run: cargo b -p client --release --features api-server/coco-as-builtin,api-server/rustls
+    - name: Build bins
+      working-directory: test
+      run: make bins
 
     - name: Set cc_kbc sample attester env
       if: matrix.tee == 'sample'
       run: echo "AA_SAMPLE_ATTESTER_TEST=1" >> "$GITHUB_ENV"
 
-    - name: Retrieve secret resource with client
-      run: |
-        sudo -E ./target/release/client get-resource \
-          --path one/two/three \
-          | base64 -d \
-          > roundtrip_secret
-        diff a_secret roundtrip_secret
+    - name: Run e2e test
+      working-directory: test
+      run: sudo -E make e2e-test

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,93 @@
+name: e2e
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+# Self-hosted runners do not set -o pipefail otherwise
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  e2e-test:
+    strategy:
+      matrix:
+        tee: [ "sample", "az-snp-vtpm" ]
+
+    runs-on: ${{ ((matrix.tee == 'az-snp-vtpm') && fromJSON('["self-hosted","azure-cvm"]')) || 'ubuntu-22.04' }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+
+    - uses: actions/setup-go@v4
+      with:
+        go-version: stable
+
+    - name: Install dependencies
+      env:
+        SGX_URL: https://download.01.org/intel-sgx/sgx_repo/ubuntu
+      run: |
+        curl -L "${SGX_URL}/intel-sgx-deb.key" | sudo apt-key add -
+        echo "deb [arch=amd64] ${SGX_URL} jammy main" \
+          | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          clang \
+          libsgx-dcap-quote-verify-dev \
+          libtdx-attest-dev \
+          libtss2-dev \
+          openssl \
+          pkg-config \
+          protobuf-compiler
+
+    - name: Set up rust build cache
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          target/
+        key: rust-${{ hashFiles('./Cargo.lock') }}
+
+    - name: Build kbs
+      run: cargo b -p kbs --release
+
+    - name: Start kbs
+      run: | 
+        openssl genpkey -algorithm ed25519 > kbs.key
+        openssl pkey -in kbs.key -pubout -out kbs.pem
+        sudo ./target/release/kbs \
+          --socket 127.0.0.1:8080 \
+          --insecure-http \
+          --auth-public-key ./kbs.pem &
+
+    - name: Add secret resource to kbs repository
+      env:
+        REPO_PATH: /opt/confidential-containers/kbs/repository
+      run: |
+        sudo mkdir -p "${REPO_PATH}/one/two"
+        openssl rand 16 > a_secret
+        sudo cp a_secret "${REPO_PATH}/one/two/three"
+
+    - name: Build client
+      run: cargo b -p client --release --features api-server/coco-as-builtin,api-server/rustls
+
+    - name: Set cc_kbc sample attester env
+      if: matrix.tee == 'sample'
+      run: echo "AA_SAMPLE_ATTESTER_TEST=1" >> "$GITHUB_ENV"
+
+    - name: Retrieve secret resource with client
+      run: |
+        sudo -E ./target/release/client get-resource \
+          --path one/two/three \
+          | base64 -d \
+          > roundtrip_secret
+        diff a_secret roundtrip_secret

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 /target
 
 data
+
+# test
+test/*
+!test/Makfile

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,71 @@
+OS := $(shell lsb_release -si)
+RELEASE := $(shell lsb_release -sr)
+SGX_REPO_URL := https://download.01.org/intel-sgx/sgx_repo/ubuntu
+KBS_REPO_PATH := /opt/confidential-containers/kbs/repository
+MAKEFILE_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+PROJECT_DIR := $(MAKEFILE_DIR)/..
+
+ifeq ($(OS),Ubuntu)
+    ifneq ($(RELEASE),22.04)
+        $(error "This Makefile requires Ubuntu 22.04")
+    endif
+else
+    $(error "This Makefile requires Ubuntu")
+endif
+
+.PHONY: install-dependencies
+install-dependencies:
+	curl -L "$(SGX_REPO_URL)/intel-sgx-deb.key" | sudo apt-key add - && \
+	echo "deb [arch=amd64] $(SGX_REPO_URL) jammy main" \
+		| sudo tee /etc/apt/sources.list.d/intel-sgx.list && \
+	sudo apt-get update && \
+	sudo apt-get install -y \
+		build-essential \
+		clang \
+		libsgx-dcap-quote-verify-dev \
+		libtdx-attest-dev \
+		libtss2-dev \
+		openssl \
+		pkg-config \
+		protobuf-compiler
+
+kbs:
+	cd $(PROJECT_DIR) && \
+	cargo build -p kbs --release && \
+	install -D --compare ./target/release/kbs $(CURDIR)/kbs
+
+client:
+	cd $(PROJECT_DIR) && \
+	cargo build -p client --release \
+		--features api-server/coco-as-builtin,api-server/rustls && \
+	install -D --compare $(PROJECT_DIR)/target/release/client $(CURDIR)/client
+
+.PHONY: bins
+bins: kbs client
+
+kbs.key:
+	openssl genpkey -algorithm ed25519 > kbs.key
+
+kbs.pem: kbs.key
+	openssl pkey -in kbs.key -pubout -out kbs.pem
+
+$(KBS_REPO_PATH)/one/two/three:
+	mkdir -p $(KBS_REPO_PATH)/one/two && \
+	openssl rand 16 > $(KBS_REPO_PATH)/one/two/three
+
+.PHONY: start-kbs
+start-kbs: kbs kbs.pem $(KBS_REPO_PATH)/one/two/three
+	./kbs \
+	  --socket 127.0.0.1:8080 \
+	  --insecure-http \
+	  --auth-public-key ./kbs.pem &
+
+.PHONY: e2e-test
+e2e-test: start-kbs client
+	./client get-resource --path one/two/three | base64 -d > roundtrip_secret && \
+	diff $(KBS_REPO_PATH)/one/two/three roundtrip_secret
+	@echo "e2e test passed"
+
+.PHONY: clean
+clean:
+	rm kbs kbs.key kbs.pem client roundtrip_secret $(KBS_REPO_PATH)/one/two/three


### PR DESCRIPTION
This test aims to cover a secure key release using remote-attestation. It will help us to detect unintented breakage and document a green path for the kbs protocol. Via the `./tools/client` project we retrieve evidence and request a secret from a local kbs instance, which is verifying the evidence and releasing key on successful attestation.

fixes #36
fixes #100

The idea is that we add self-hosted runners for TDX, SGX, SNP attester/verifier pairs to the test matrix. Those will most likely require self-hosted runners, that horrible yaml/json contraption in `runs-on` can be used for that.

edit: the azure cvm test will not be executed, since the repo needs to be configured to accept self-hosted runners (look [here](https://github.com/mkulke/kbs/actions/runs/5177762610/jobs/9328275847) for a successful run)
