### PR TITLE
kbs: Add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@kbs-maintainers


### PR DESCRIPTION
Have a more formalized way of defining maintainership.

KBS is maintained by the @kbs-maintainers team.