### PR TITLE
ci: don't fail fast on matrix runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,5 @@
+name: rust tests
+
 on:
   push:
     branches: [ "main" ]
@@ -10,6 +12,7 @@ env:
 jobs:
   ci:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable


### PR DESCRIPTION
This way, other matrix runs won't be canceled if one of them fails.