### PR TITLE
Feature: Add access resource using the KBS-provisioned Token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rsa 0.7.2",
+ "rstest",
  "rustls 0.20.8",
  "rustls-pemfile",
  "semver 1.0.17",
@@ -416,6 +417,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
+ "thiserror",
  "tokio",
  "tonic",
  "tonic-build",
@@ -479,7 +481,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -920,7 +922,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1279,7 +1281,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1359,7 +1361,7 @@ checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1568,7 +1570,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1582,6 +1584,12 @@ name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1847,15 +1855,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
- "rustls 0.21.1",
+ "rustls 0.21.5",
  "tokio",
- "tokio-rustls 0.24.0",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2537,7 +2546,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2793,7 +2802,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2925,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -3004,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -3100,6 +3109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
+name = "relative-path"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
+
+[[package]]
 name = "reqwest"
 version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,14 +3141,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.1",
+ "rustls 0.21.5",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.0",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3231,6 +3246,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b96577ca10cb3eade7b337eb46520108a67ca2818a24d0b63f41fd62bc9651c"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e674cf31712b8bb15fdbca3ec0c1b9d825c5a24407ff2b7e005fb6a29ba03"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.0",
+ "syn 2.0.25",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -3312,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
 dependencies = [
  "ring",
  "untrusted",
@@ -3494,7 +3538,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3804,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3892,22 +3936,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4002,7 +4046,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4040,11 +4084,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.1",
+ "rustls 0.21.5",
  "tokio",
 ]
 
@@ -4167,7 +4211,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -4412,7 +4456,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -4446,7 +4490,7 @@ checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4746,7 +4790,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.25",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ async-trait = "0.1.31"
 base64 = "0.13.1"
 env_logger = "0.10.0"
 log = "0.4.17"
+rstest = "0.18.1"
 serde_json = "1.0.89"
+thiserror = "1.0"
 tokio = { version = "1.23.0", features = ["full"] }
 tempfile = "3.4.0"

--- a/docs/kbs.yaml
+++ b/docs/kbs.yaml
@@ -95,6 +95,7 @@ paths:
           name: kbs-session-id
           schema:
             type: string
+          required: false
         - name: repository
           in: path
           description: A parent path of resource, can be empty to use the default repository.
@@ -113,6 +114,16 @@ paths:
           schema:
             type: string
           required: true
+      requestBody:
+        required: false
+        description: >-
+          A KBS provisioned token that includes the Tee public key.
+          KBS will then use the Tee public key to perform JSON Web Encryption
+          for the resource in a response if the token is valid.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttestationToken'
       responses:
         200:
           description: >-

--- a/docs/kbs_attestation_protocol.md
+++ b/docs/kbs_attestation_protocol.md
@@ -340,6 +340,14 @@ protocol, where attesters authenticate themselves against a KBS implementation.
 This leads to the second phase, during which authenticated attesters can request
 protected resources from the KBS.
 
+Attesters can access protected resources by providing the KBS with either the HTTP
+cookie or the Attestation Results token returned as part of the Attestation HTTP
+response. The former is usually short-lived and is typically used for one-time,
+synchronous resources request. For longer KBS sessions, it is more convenient to
+use the latter.    
+
+### HTTP Cookie Authentication
+
 The KBS implementation keeps track of attestation results and binds them to a
 cookie identifier. During the second phase, the KBS can then decide if a
 specific resource could be released to a given attester, by mapping the cookie
@@ -370,7 +378,7 @@ content is set to a [KBS Response](#response) JSON payload:
     ┃                                                   ┃
     ┃                                                   ┃
     ┃                                                   ┃
-    ▽        Figure 2: KBS Resource Request Phase       ▽
+    ▽   Figure 2: KBS Resource Request Phase - Session  ▽
 ```
 
 A request for protected resource can fail for three reasons:
@@ -378,6 +386,51 @@ A request for protected resource can fail for three reasons:
 1. The requester is not authenticated and thus can not provide the right cookie
    identifier. The KBS implementation sends an HTTP response with a 401
    (`Unauthorized`) status code.
+2. The attester is authenticated but requests a resource that it's not allowed
+   to receive. The KBS implementation sends an HTTP response with a 403
+   (`Forbidden`) status code.
+3. The requested resource does not exist. The KBS implementation sends an HTTP
+   response with a 404 (`Not Found`) status code.
+
+### Attestation Results Token Authentication
+
+As part of the Authentication process, the requester generates a TEE asymmetric key 
+pair. Upon successful Attestation, the KBS provisions a token that contains the
+Attestation Results and endorsements for the TEE public key.
+
+To request a protected resource from the KBS, the attester sends a `GET` request
+to a resource specific endpoint with the token as the bearer authorization. If the
+token passes verification, the KBS will respond to the `GET` request with an HTTP
+response whose content is set to a [KBS Response](#response) JSON payload. The
+symetric key inside the [KBS Response](#response) JSON payload will be wrapped by
+the public key inside the token.
+
+```
+┌──────────┐                                         ┌─────┐
+│ Attester │                                         │ KBS │
+└───┳──────┘                                         └──┳──┘
+    ┃            ┌─────────────────────────┐            ┃
+    ┃────────────│GET /kbs/v0/<resource_id>│───────────▶┃
+    ┃      ┌─────┴─────────────────────────┴────┐       ┃
+    ┃      │Header: Authorization Bearer        │       ┃
+    ┃      │Body: N/A                           │       ┃
+    ┃      └────────────────────────────────────┘       ┃
+    ┃                    ┌────────┐                     ┃
+    ┃◀───────────────────│Response│─────────────────────┃
+    ┃     ┌──────────────└────────┘───────────────┐     ┃
+    ┃     │Header: No Cookie                      │     ┃
+    ┃     │Body: Response                         │     ┃
+    ┃     └───────────────────────────────────────┘     ┃
+    ┃                                                   ┃
+    ┃                                                   ┃
+    ┃                                                   ┃
+    ▽    Figure 3: KBS Resource Request Phase - Token   ▽
+```
+
+A request for protected resource can fail for three reasons:
+
+1. The requester is not authenticated and thus can not provide the valid token.
+   The KBS implementation sends an HTTP response with a 401 (`Unauthorized`) status code.
 2. The attester is authenticated but requests a resource that it's not allowed
    to receive. The KBS implementation sends an HTTP response with a 403
    (`Forbidden`) status code.

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -45,6 +45,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json.workspace = true
 strum = "0.24.1"
 strum_macros = "0.24.1"
+thiserror.workspace = true
 tokio.workspace = true
 tonic = { version = "0.9", optional = true }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
@@ -53,6 +54,7 @@ p256 = { version = "0.13.2", features = [ "ecdsa" ] }
 
 [dev-dependencies]
 tempfile.workspace = true
+rstest.workspace = true
 
 [build-dependencies]
 anyhow = "1"

--- a/src/api/src/http/attest.rs
+++ b/src/api/src/http/attest.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use log::{error, info};
 use serde_json::json;
 
 macro_rules! unauthorized {
@@ -39,7 +40,7 @@ pub(crate) async fn auth(
     map: web::Data<SessionMap<'_>>,
     timeout: web::Data<i64>,
 ) -> HttpResponse {
-    log::info!("request: {:?}", &request);
+    info!("request: {:?}", &request);
 
     let session = match Session::from_request(&request, *timeout.into_inner()) {
         Ok(s) => s,
@@ -111,9 +112,7 @@ pub(crate) async fn attest(
     {
         Ok(results) => {
             if !results.allow() {
-                log::error!("Evidence verification failed {:?}", results.output());
-                unauthorized!(VerificationFailed, "Attestation failure");
-            }
+        error!("Evidence verification failed {:?}", results.output());
 
             session.set_tee_public_key(attestation.tee_pubkey.clone());
             session.set_attestation_results(results.clone());

--- a/src/api/src/http/error.rs
+++ b/src/api/src/http/error.rs
@@ -47,6 +47,9 @@ pub enum Error {
     #[error("Policy error: {0}")]
     PolicyEndpoint(String),
 
+    #[error("Public key get failed: {0}")]
+    PublicKeyGetFailed(String),
+
     #[error("Read secret failed: {0}")]
     ReadSecretFailed(String),
 
@@ -55,6 +58,9 @@ pub enum Error {
 
     #[error("Attestation token issue failed: {0}")]
     TokenIssueFailed(String),
+
+    #[error("Received an illegal token: {0}")]
+    TokenParseFailed(String),
 
     #[error("The cookie is unauthenticated")]
     UnAuthenticatedCookie,
@@ -120,9 +126,11 @@ mod tests {
     #[case(Error::InvalidRequest("test".into()))]
     #[case(Error::JWEFailed("test".into()))]
     #[case(Error::PolicyEndpoint("test".into()))]
+    #[case(Error::PublicKeyGetFailed("test".into()))]
     #[case(Error::ReadSecretFailed("test".into()))]
     #[case(Error::SetSecretFailed("test".into()))]
     #[case(Error::TokenIssueFailed("test".into()))]
+    #[case(Error::TokenParseFailed("test".into()))]
     #[case(Error::UnAuthenticatedCookie)]
     #[case(Error::UserPublicKeyNotProvided)]
     fn into_error_response(#[case] err: Error) {

--- a/src/api/src/http/error.rs
+++ b/src/api/src/http/error.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2023 by Alibaba.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This Error type helps to work with Actix-web
+
+use std::fmt::{Display, Write};
+
+use actix_web::{
+    body::BoxBody,
+    http::header::{self, TryIntoHeaderValue},
+    web::BytesMut,
+    HttpResponse, Responder, ResponseError,
+};
+use kbs_types::ErrorInformation;
+use serde::Serialize;
+use strum_macros::AsRefStr;
+use thiserror::Error;
+
+const ERROR_TYPE_PREFIX: &str = "https://github.com/confidential-containers/kbs/errors";
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, AsRefStr, Debug)]
+pub enum Error {
+    #[error("Attestation failed: {0}")]
+    AttestationFailed(String),
+
+    #[error("The cookie is expired")]
+    ExpiredCookie,
+
+    #[error("Authentication failed: {0}")]
+    FailedAuthentication(String),
+
+    #[error("The cookie is invalid")]
+    InvalidCookie,
+
+    #[error("The request is invalid: {0}")]
+    InvalidRequest(String),
+
+    #[error("Json Web Encryption failed: {0}")]
+    JWEFailed(String),
+
+    #[error("The cookie is missing")]
+    MissingCookie,
+
+    #[error("Policy error: {0}")]
+    PolicyEndpoint(String),
+
+    #[error("Read secret failed: {0}")]
+    ReadSecretFailed(String),
+
+    #[error("Set secret failed: {0}")]
+    SetSecretFailed(String),
+
+    #[error("Attestation token issue failed: {0}")]
+    TokenIssueFailed(String),
+
+    #[error("The cookie is unauthenticated")]
+    UnAuthenticatedCookie,
+
+    #[error("User public key not provided when launching the KBS")]
+    UserPublicKeyNotProvided,
+}
+
+/// For example, if we want to raise an error of `MissingCookie`
+/// ```no-run
+/// raise_error!(Error::MissingCookie);
+/// ```
+/// is short for
+/// ```no-run
+/// return Err(Error::MissingCookie);
+/// ```
+#[macro_export]
+macro_rules! raise_error {
+    ($error: expr) => {
+        return Err($error)
+    };
+}
+
+impl ResponseError for Error {
+    fn error_response(&self) -> HttpResponse {
+        let mut detail = String::new();
+
+        // The write macro here will only raise error when OOM of the string.
+        write!(&mut detail, "{}", self).expect("written error response failed");
+        let info = ErrorInformation {
+            error_type: format!("{ERROR_TYPE_PREFIX}/{}", self.as_ref()),
+            detail,
+        };
+
+        // All the fields inside the ErrorInfo are printable characters, so this
+        // error cannot happen.
+        // A test covering all the possible error types are given to ensure this.
+        let body = serde_json::to_string(&info).expect("serialize error response failed");
+
+        // Due to the definition of KBS attestation protocol, we set the http code.
+        let mut res = match self {
+            Error::ReadSecretFailed(_) => HttpResponse::NotFound(),
+            _ => HttpResponse::Unauthorized(),
+        };
+
+        res.body(BoxBody::new(body))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::http::Error;
+
+    #[rstest]
+    #[case(Error::AttestationFailed("test".into()))]
+    #[case(Error::ExpiredCookie)]
+    #[case(Error::FailedAuthentication("test".into()))]
+    #[case(Error::InvalidCookie)]
+    #[case(Error::ExpiredCookie)]
+    #[case(Error::MissingCookie)]
+    #[case(Error::InvalidRequest("test".into()))]
+    #[case(Error::JWEFailed("test".into()))]
+    #[case(Error::PolicyEndpoint("test".into()))]
+    #[case(Error::ReadSecretFailed("test".into()))]
+    #[case(Error::SetSecretFailed("test".into()))]
+    #[case(Error::TokenIssueFailed("test".into()))]
+    #[case(Error::UnAuthenticatedCookie)]
+    #[case(Error::UserPublicKeyNotProvided)]
+    fn into_error_response(#[case] err: Error) {
+        let _ = actix_web::ResponseError::error_response(&err);
+    }
+}

--- a/src/api/src/http/mod.rs
+++ b/src/api/src/http/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use actix_web::Responder;
 use actix_web::{body::BoxBody, web, HttpRequest, HttpResponse};
 use jwt_simple::prelude::Ed25519PublicKey;
 use kbs_types::{Attestation, Challenge, ErrorInformation, Request};
@@ -17,6 +18,7 @@ use crate::token::AttestationTokenBroker;
 
 mod attest;
 mod config;
+mod error;
 mod public;
 mod resource;
 
@@ -32,22 +34,4 @@ pub use public::*;
 /// RESTful APIs that to get secret resources, need attestation verification
 pub use resource::*;
 
-const ERROR_TYPE_PREFIX: &str = "https://github.com/confidential-containers/kbs/errors/";
-
-#[derive(Debug, EnumString)]
-pub enum ErrorInformationType {
-    ExpiredCookie,
-    FailedAuthentication,
-    InvalidCookie,
-    MissingCookie,
-    UnAuthenticatedCookie,
-    VerificationFailed,
-    JWTVerificationFailed,
-}
-
-pub(crate) fn kbs_error_info(error_type: ErrorInformationType, detail: &str) -> ErrorInformation {
-    ErrorInformation {
-        error_type: format!("{ERROR_TYPE_PREFIX}{error_type:?}"),
-        detail: detail.to_string(),
-    }
-}
+pub use error::*;

--- a/src/api/src/http/resource.rs
+++ b/src/api/src/http/resource.rs
@@ -2,8 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use actix_web::{http::header::Header, web::Bytes};
+use actix_web_httpauth::headers::authorization::{Authorization, Bearer};
+use aes_gcm::{aead::Aead, Aes256Gcm, KeyInit, Nonce};
 use anyhow::{anyhow, bail};
+use kbs_types::{Response, TeePubKey};
 use log::{error, info};
+use rand::{rngs::OsRng, Rng};
+use rsa::{BigUint, PaddingScheme, PublicKey, RsaPublicKey};
+use serde::Deserialize;
+use serde_json::{json, Deserializer, Value};
 
 use crate::raise_error;
 
@@ -15,7 +23,57 @@ pub(crate) async fn get_resource(
     request: HttpRequest,
     repository: web::Data<Arc<RwLock<dyn Repository + Send + Sync>>>,
     map: web::Data<SessionMap<'_>>,
+    token_broker: web::Data<Arc<RwLock<dyn AttestationTokenBroker + Send + Sync>>>,
 ) -> Result<HttpResponse> {
+    let pubkey = if let Ok(pkey) = get_pubkey_from_cookie(&request, map).await {
+        info!("Get pkey from session.");
+        pkey
+    } else {
+        info!("Try get pkey from the auth header");
+        get_pubkey_from_header(&request, token_broker).await?
+    };
+
+    let resource_description = ResourceDesc {
+        repository_name: request
+            .match_info()
+            .get("repository")
+            .unwrap_or("default")
+            .to_string(),
+        resource_type: request
+            .match_info()
+            .get("type")
+            .ok_or_else(|| Error::InvalidRequest(String::from("no `type` in url")))?
+            .to_string(),
+        resource_tag: request
+            .match_info()
+            .get("tag")
+            .ok_or_else(|| Error::InvalidRequest(String::from("no `tag` in url")))?
+            .to_string(),
+    };
+
+    info!("Resource description: {:?}", &resource_description);
+
+    let resource_byte = repository
+        .read()
+        .await
+        .read_secret_resource(resource_description)
+        .await
+        .map_err(|e| Error::ReadSecretFailed(e.to_string()))?;
+
+    let jwe = jwe(pubkey, resource_byte)?;
+
+    let res = serde_json::to_string(&jwe).map_err(|e| Error::JWEFailed(e.to_string()))?;
+
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .body(res))
+}
+
+async fn get_pubkey_from_cookie(
+    request: &HttpRequest,
+    map: web::Data<SessionMap<'_>>,
+) -> Result<TeePubKey> {
+    // check cookie
     let cookie = request
         .cookie(KBS_SESSION_ID)
         .ok_or(Error::UnAuthenticatedCookie)?;
@@ -39,47 +97,91 @@ pub(crate) async fn get_resource(
         raise_error!(Error::ExpiredCookie);
     }
 
-    let resource_description = ResourceDesc {
-        repository_name: request
-            .match_info()
-            .get("repository")
-            .unwrap_or("default")
-            .to_string(),
-        resource_type: request
-            .match_info()
-            .get("type")
-            .ok_or_else(|| Error::InvalidRequest(String::from("no `type` in url")))?
-            .to_string(),
-        resource_tag: request
-            .match_info()
-            .get("tag")
-            .ok_or_else(|| Error::InvalidRequest(String::from("no `tag` in url")))?
-            .to_string(),
-    };
+    let pubkey = session.tee_public_key().ok_or(Error::PublicKeyGetFailed(
+        "No public key in the session".into(),
+    ))?;
 
-    info!("Resource description: {:?}", &resource_description);
+    Ok(pubkey)
+}
 
-    if session.tee_public_key().is_none() {
-        error!("TEE pubkey not found");
-        raise_error!(Error::FailedAuthentication(String::from(
-            "Teepub key not found in session"
+async fn get_pubkey_from_header(
+    request: &HttpRequest,
+    token_broker: web::Data<Arc<RwLock<dyn AttestationTokenBroker + Send + Sync>>>,
+) -> Result<TeePubKey> {
+    let bearer = Authorization::<Bearer>::parse(request)
+        .map_err(|e| Error::InvalidRequest(format!("parse Authorization header failed: {e}")))?
+        .into_scheme();
+
+    let token = bearer.token().to_string();
+
+    let claims = token_broker
+        .read()
+        .await
+        .verify(token)
+        .map_err(|e| Error::TokenParseFailed(format!("verify token failed: {e}")))?;
+    let claims: Value = serde_json::from_str(&claims)
+        .map_err(|e| Error::TokenParseFailed(format!("illegal custom claims: {e}")))?;
+
+    let pkey_value = claims
+        .get("tee-pubkey")
+        .ok_or(Error::TokenParseFailed(String::from(
+            "No `tee-pubkey` in the custom claims",
+        )))?;
+    TeePubKey::deserialize(pkey_value)
+        .map_err(|e| Error::TokenParseFailed(format!("illegal custom claims: {e}")))
+}
+
+const RSA_ALGORITHM: &str = "RSA1_5";
+const AES_GCM_256_ALGORITHM: &str = "A256GCM";
+
+pub(crate) fn jwe(tee_pub_key: TeePubKey, payload_data: Vec<u8>) -> Result<Response> {
+    if tee_pub_key.alg != *RSA_ALGORITHM {
+        raise_error!(Error::JWEFailed(format!(
+            "algorithm is not {RSA_ALGORITHM} but {}",
+            tee_pub_key.alg
         )));
     }
 
-    let resource_byte = repository
-        .read()
-        .await
-        .read_secret_resource(resource_description)
-        .await
-        .map_err(|e| Error::ReadSecretFailed(e.to_string()))?;
+    let mut rng = rand::thread_rng();
 
-    let jwe = session
-        .to_jwe(resource_byte)
-        .map_err(|e| Error::JWEFailed(e.to_string()))?;
+    let aes_sym_key = Aes256Gcm::generate_key(&mut OsRng);
+    let cipher = Aes256Gcm::new(&aes_sym_key);
+    let iv = rng.gen::<[u8; 12]>();
+    let nonce = Nonce::from_slice(&iv);
+    let encrypted_payload_data = cipher
+        .encrypt(nonce, payload_data.as_slice())
+        .map_err(|e| Error::JWEFailed(format!("AES encrypt Resource payload failed: {e:?}")))?;
 
-    let res = serde_json::to_string(&jwe).map_err(|e| Error::JWEFailed(e.to_string()))?;
+    let k_mod = base64::decode_config(&tee_pub_key.k_mod, base64::URL_SAFE_NO_PAD)
+        .map_err(|e| Error::JWEFailed(format!("base64 decode k_mod failed: {e:?}")))?;
+    let n = BigUint::from_bytes_be(&k_mod);
+    let k_exp = base64::decode_config(&tee_pub_key.k_exp, base64::URL_SAFE_NO_PAD)
+        .map_err(|e| Error::JWEFailed(format!("base64 decode k_exp failed: {e:?}")))?;
+    let e = BigUint::from_bytes_be(&k_exp);
 
-    Ok(HttpResponse::Ok()
-        .content_type("application/json")
-        .body(res))
+    let rsa_pub_key = RsaPublicKey::new(n, e).map_err(|e| {
+        Error::JWEFailed(format!(
+            "Building RSA key from modulus and exponent failed: {e:?}"
+        ))
+    })?;
+    let padding = PaddingScheme::new_pkcs1v15_encrypt();
+    let sym_key: &[u8] = aes_sym_key.as_slice();
+    let wrapped_sym_key = rsa_pub_key
+        .encrypt(&mut rng, padding, sym_key)
+        .map_err(|e| Error::JWEFailed(format!("RSA encrypt sym key failed: {e:?}")))?;
+
+    let protected_header = json!(
+    {
+       "alg": RSA_ALGORITHM.to_string(),
+       "enc": AES_GCM_256_ALGORITHM.to_string(),
+    });
+
+    Ok(Response {
+        protected: serde_json::to_string(&protected_header)
+            .map_err(|e| Error::JWEFailed(format!("serde protected_header failed: {e}")))?,
+        encrypted_key: base64::encode_config(wrapped_sym_key, base64::URL_SAFE_NO_PAD),
+        iv: base64::encode_config(iv, base64::URL_SAFE_NO_PAD),
+        ciphertext: base64::encode_config(encrypted_payload_data, base64::URL_SAFE_NO_PAD),
+        tag: "".to_string(),
+    })
 }

--- a/src/api/src/http/resource.rs
+++ b/src/api/src/http/resource.rs
@@ -2,24 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{anyhow, bail};
 use log::{error, info};
 
+use crate::raise_error;
+
 use super::*;
-
-macro_rules! unauthorized {
-    ($error_type: ident, $reason: expr) => {
-        return HttpResponse::Unauthorized()
-            .json(kbs_error_info(ErrorInformationType::$error_type, $reason))
-    };
-}
-
-macro_rules! internal {
-    ($reason: expr) => {
-        return HttpResponse::InternalServerError()
-            .message_body(BoxBody::new($reason))
-            .unwrap()
-    };
-}
 
 /// GET /resource/{repository}/{type}/{tag}
 /// GET /resource/{type}/{tag}
@@ -27,23 +15,15 @@ pub(crate) async fn get_resource(
     request: HttpRequest,
     repository: web::Data<Arc<RwLock<dyn Repository + Send + Sync>>>,
     map: web::Data<SessionMap<'_>>,
-) -> HttpResponse {
-    let cookie = match request.cookie(KBS_SESSION_ID) {
-        None => {
-            error!("Missing KBS cookie");
-            unauthorized!(MissingCookie, "");
-        }
-        Some(c) => c,
-    };
+) -> Result<HttpResponse> {
+    let cookie = request
+        .cookie(KBS_SESSION_ID)
+        .ok_or(Error::UnAuthenticatedCookie)?;
 
     let session_map = map.sessions.read().await;
-    let locked_session = match session_map.get(cookie.value()) {
-        None => {
-            error!("Invalid KBS cookie {}", cookie.value());
-            unauthorized!(InvalidCookie, cookie.value());
-        }
-        Some(ls) => ls,
-    };
+    let locked_session = session_map
+        .get(cookie.value())
+        .ok_or(Error::UnAuthenticatedCookie)?;
 
     let session = locked_session.lock().await;
 
@@ -51,12 +31,12 @@ pub(crate) async fn get_resource(
 
     if !session.is_authenticated() {
         error!("UnAuthenticated KBS cookie {}", cookie.value());
-        unauthorized!(UnAuthenticatedCookie, cookie.value());
+        raise_error!(Error::UnAuthenticatedCookie);
     }
 
     if session.is_expired() {
         error!("Expired KBS cookie {}", cookie.value());
-        unauthorized!(ExpiredCookie, cookie.value());
+        raise_error!(Error::ExpiredCookie);
     }
 
     let resource_description = ResourceDesc {
@@ -65,33 +45,41 @@ pub(crate) async fn get_resource(
             .get("repository")
             .unwrap_or("default")
             .to_string(),
-        resource_type: request.match_info().get("type").unwrap().to_string(),
-        resource_tag: request.match_info().get("tag").unwrap().to_string(),
+        resource_type: request
+            .match_info()
+            .get("type")
+            .ok_or_else(|| Error::InvalidRequest(String::from("no `type` in url")))?
+            .to_string(),
+        resource_tag: request
+            .match_info()
+            .get("tag")
+            .ok_or_else(|| Error::InvalidRequest(String::from("no `tag` in url")))?
+            .to_string(),
     };
 
     info!("Resource description: {:?}", &resource_description);
 
     if session.tee_public_key().is_none() {
-        internal!(format!("TEE Pubkey not found"));
+        error!("TEE pubkey not found");
+        raise_error!(Error::FailedAuthentication(String::from(
+            "Teepub key not found in session"
+        )));
     }
 
-    let resource_byte = match repository
+    let resource_byte = repository
         .read()
         .await
         .read_secret_resource(resource_description)
         .await
-    {
-        Ok(byte) => byte,
-        Err(e) => internal!(format!(
-            "Read secret resource from repository failed: {:?}",
-            e
-        )),
-    };
+        .map_err(|e| Error::ReadSecretFailed(e.to_string()))?;
 
-    match session.to_jwe(resource_byte) {
-        Ok(response) => HttpResponse::Ok()
-            .content_type("application/json")
-            .body(serde_json::to_string(&response).unwrap()),
-        Err(e) => internal!(format!("Generate Confidential Response failed: {e}")),
-    }
+    let jwe = session
+        .to_jwe(resource_byte)
+        .map_err(|e| Error::JWEFailed(e.to_string()))?;
+
+    let res = serde_json::to_string(&jwe).map_err(|e| Error::JWEFailed(e.to_string()))?;
+
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .body(res))
 }

--- a/src/api/src/session.rs
+++ b/src/api/src/session.rs
@@ -6,25 +6,15 @@ use actix_web::cookie::{
     time::{Duration, OffsetDateTime},
     Cookie, Expiration,
 };
-use aes_gcm::{
-    aead::{Aead, KeyInit, OsRng},
-    Aes256Gcm, Nonce,
-};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use as_types::AttestationResults;
-use kbs_types::{Request, Response, Tee, TeePubKey};
+use kbs_types::{Request, Tee, TeePubKey};
 use rand::{thread_rng, Rng};
-use rsa::{BigUint, PaddingScheme, PublicKey, RsaPublicKey};
 use semver::Version;
-use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
-
-const RSA_KEY_TYPE: &str = "RSA";
-const RSA_ALGORITHM: &str = "RSA1_5";
-const AES_GCM_256_ALGORITHM: &str = "A256GCM";
 
 pub(crate) static KBS_SESSION_ID: &str = "kbs-session-id";
 
@@ -124,55 +114,6 @@ impl<'a> Session<'a> {
 
     pub fn set_tee_public_key(&mut self, key: TeePubKey) {
         self.tee_pub_key = Some(key)
-    }
-
-    pub fn to_jwe(&self, payload_data: Vec<u8>) -> Result<Response> {
-        let tee_pub_key = self
-            .tee_public_key()
-            .ok_or_else(|| anyhow!("No TEE public Key"))?;
-        if tee_pub_key.kty != *RSA_KEY_TYPE {
-            bail!("TEE pub key has unsupported JWK key type (kty)");
-        }
-        if tee_pub_key.alg != *RSA_ALGORITHM {
-            bail!("TEE pub key has unsupported JWK algorithm (alg)");
-        }
-
-        let mut rng = rand::thread_rng();
-
-        let aes_sym_key = Aes256Gcm::generate_key(&mut OsRng);
-        let cipher = Aes256Gcm::new(&aes_sym_key);
-        let iv = rng.gen::<[u8; 12]>();
-        let nonce = Nonce::from_slice(&iv);
-        let encrypted_payload_data = cipher
-            .encrypt(nonce, payload_data.as_slice())
-            .map_err(|e| anyhow!("AES encrypt Resource payload failed: {:?}", e))?;
-
-        let k_mod = base64::decode_config(&tee_pub_key.k_mod, base64::URL_SAFE_NO_PAD)?;
-        let n = BigUint::from_bytes_be(&k_mod);
-        let k_exp = base64::decode_config(&tee_pub_key.k_exp, base64::URL_SAFE_NO_PAD)?;
-        let e = BigUint::from_bytes_be(&k_exp);
-
-        let rsa_pub_key = RsaPublicKey::new(n, e)
-            .map_err(|e| anyhow!("Building RSA key from modulus and exponent failed: {:?}", e))?;
-        let padding = PaddingScheme::new_pkcs1v15_encrypt();
-        let sym_key: &[u8] = aes_sym_key.as_slice();
-        let wrapped_sym_key = rsa_pub_key
-            .encrypt(&mut rng, padding, sym_key)
-            .map_err(|e| anyhow!("RSA encrypt sym key failed: {:?}", e))?;
-
-        let protected_header = json!(
-        {
-           "alg": RSA_ALGORITHM.to_string(),
-           "enc": AES_GCM_256_ALGORITHM.to_string(),
-        });
-
-        Ok(Response {
-            protected: serde_json::to_string(&protected_header)?,
-            encrypted_key: base64::encode_config(wrapped_sym_key, base64::URL_SAFE_NO_PAD),
-            iv: base64::encode_config(iv, base64::URL_SAFE_NO_PAD),
-            ciphertext: base64::encode_config(encrypted_payload_data, base64::URL_SAFE_NO_PAD),
-            tag: "".to_string(),
-        })
     }
 }
 


### PR DESCRIPTION
This PR mainly aims to add a new feature that a requester can bring the KBS-provisioned token to access the resources. The rationale behind this is the token is always short-lived, which could help decrease the risk of token leakage.

This PR also refactor the error handling of the `http` module a little to use the question mark `?` for better error handling.

Close #129 