### PR TITLE
deps: bump dependencies for v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 [[package]]
 name = "as-types"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git?rev=96b6c6a#96b6c6a4b2e1e328c57ecbc886bfa30469373153"
+source = "git+https://github.com/confidential-containers/attestation-service.git?tag=v0.7.0#0ada0f443a350114a979544b2a77b6b42eb7886c"
 dependencies = [
  "kbs-types",
  "serde",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git?rev=96b6c6a#96b6c6a4b2e1e328c57ecbc886bfa30469373153"
+source = "git+https://github.com/confidential-containers/attestation-service.git?tag=v0.7.0#0ada0f443a350114a979544b2a77b6b42eb7886c"
 dependencies = [
  "anyhow",
  "as-types",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "attester"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=43f6832#43f68320ed78cef438c838c10a6f462c06bad83f"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.7.0#88dcc147ba8ddf34e8425c98d5931df8a995f04a"
 dependencies = [
  "anyhow",
  "az-snp-vtpm",
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=43f6832#43f68320ed78cef438c838c10a6f462c06bad83f"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.7.0#88dcc147ba8ddf34e8425c98d5931df8a995f04a"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2134,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "kbs_protocol"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=43f6832#43f68320ed78cef438c838c10a6f462c06bad83f"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.7.0#88dcc147ba8ddf34e8425c98d5931df8a995f04a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -22,8 +22,8 @@ actix-web-httpauth = "0.8.0"
 aes-gcm = "0.10.1"
 anyhow.workspace = true
 async-trait.workspace = true
-as-types = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "96b6c6a"}
-attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, rev = "96b6c6a", optional = true}
+as-types = { git = "https://github.com/confidential-containers/attestation-service.git", tag = "v0.7.0"}
+attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, tag = "v0.7.0", optional = true}
 base64.workspace = true
 cfg-if = "1.0.0"
 elliptic-curve = { version = "0.13.4", features = ["arithmetic", "pem"] }

--- a/tools/client/Cargo.toml
+++ b/tools/client/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-as-types = { git = "https://github.com/confidential-containers/attestation-service.git", rev = "96b6c6a"}
+as-types = { git = "https://github.com/confidential-containers/attestation-service.git", tag = "v0.7.0"}
 anyhow.workspace = true
 api-server.workspace = true
 base64.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }
 env_logger.workspace = true
 jwt-simple = "0.11.4"
-kbs_protocol = { git = "https://github.com/confidential-containers/guest-components", rev = "43f6832" }
+kbs_protocol = { git = "https://github.com/confidential-containers/guest-components", tag = "v0.7.0" }
 log.workspace = true
 reqwest = { version = "0.11.18", default-features = false, features = ["cookies", "json"] }
 serde_json.workspace = true


### PR DESCRIPTION
Now points to v0.7.0 of AS and guest-components 

Part of https://github.com/confidential-containers/confidential-containers/issues/111