### PR TITLE
Fix OpenAPI definition in kbs.yaml

### DIFF
--- a/docs/kbs.yaml
+++ b/docs/kbs.yaml
@@ -114,16 +114,6 @@ paths:
           schema:
             type: string
           required: true
-      requestBody:
-        required: false
-        description: >-
-          A KBS provisioned token that includes the Tee public key.
-          KBS will then use the Tee public key to perform JSON Web Encryption
-          for the resource in a response if the token is valid.
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AttestationToken'
       responses:
         200:
           description: >-

--- a/docs/kbs.yaml
+++ b/docs/kbs.yaml
@@ -139,7 +139,7 @@ paths:
       summary: Register a secret resource into the Key Broker Service.
       requestBody:
         required: true
-        content: *
+        content: '*'
       parameters:
         - name: repository
           in: path


### PR DESCRIPTION
- The token to request for a resource is inside the header of the HTTP request rather than the body. And due to open api spec an Authorization header shall be ignored
- Fix illegal fields