### PR TITLE
Add keys to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ data
 # test
 test/*
 !test/Makefile
+
+config/private.key
+config/public.pub


### PR DESCRIPTION
We specify generating config/private.key and config/public.pub in docs/cluster.md. Gitignore these two files to avoid accidentally committing them.