### PR TITLE
dockerfile: update builder image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67-slim as builder
+FROM rust:slim as builder
 
 WORKDIR /usr/src/kbs
 COPY . .

--- a/docker/Dockerfile.amber
+++ b/docker/Dockerfile.amber
@@ -1,4 +1,4 @@
-FROM rust:1.67 as builder
+FROM rust:latest as builder
 
 WORKDIR /usr/src/kbs
 COPY . .

--- a/docker/Dockerfile.coco-as-grpc
+++ b/docker/Dockerfile.coco-as-grpc
@@ -1,4 +1,4 @@
-FROM rust:1.67 as builder
+FROM rust:latest as builder
 
 WORKDIR /usr/src/kbs
 COPY . .


### PR DESCRIPTION
update builder iamge from 1.67 to latest.

Arm CCA's dep `half` requires rust version >=1.70

helps https://github.com/confidential-containers/kbs/pull/76

cc @chendave @jialez0 