### PR TITLE
docker: update key-broker-service Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,54 +1,56 @@
 FROM rust:slim as builder
 
-WORKDIR /usr/src/kbs
-COPY . .
-
 ENV DEBIAN_FRONTEND noninteractive
 
-# Install Build Dependencies
-RUN apt-get update && apt-get install -y apt-utils
-RUN apt-get install -y \
-    clang \
-    cmake \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     curl \
-    gnupg \
+    gpg \
+    gnupg-agent
+
+RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
+    gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | \
+    tee /etc/apt/sources.list.d/intel-sgx.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
     libclang-dev \
     libprotobuf-dev \
     libssl-dev \
     make \
+    perl \
     pkg-config \
     protobuf-compiler \
-    wget
+    wget \
+    clang \
+    cmake \
+    libtss2-dev \
+    libsgx-dcap-quote-verify-dev \
+    libtdx-attest-dev
+
 RUN wget https://go.dev/dl/go1.20.1.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.20.1.linux-amd64.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-# Install TPM Build Dependencies
-RUN apt-get install -y --no-install-recommends libtss2-dev
-
-# Install TDX Build Dependencies
-RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
-RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-    libsgx-dcap-quote-verify-dev \
-    libtdx-attest-dev
-
 # Build and Install KBS
+WORKDIR /usr/src/kbs
+COPY . .
+
 ARG KBS_FEATURES=coco-as-builtin,rustls,resource,opa
 RUN cargo install --path src/kbs --no-default-features --features ${KBS_FEATURES}
 
 FROM debian:stable-slim
 
-RUN apt-get update && apt-get install -y apt-utils
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
     clang \
     curl \
-    gnupg
+    gnupg-agent
 
 # Install TDX Runtime Dependencies
-RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
-RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list
+RUN curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
+    gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg
+RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
     libsgx-dcap-default-qpl \


### PR DESCRIPTION
Improvements and fixes:

* openssl-sys fails to build without certain .pm files so the intermediate fix is to install perl.
* reduce build steps and move "COPY" later in the build to allow caches to be used more efficiently (previously, a single modification to the repo files forced 1G of apt-get to be re-installed).
* move away from deprecated apt-key.