### PR TITLE
Bump KBS to v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "attester"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components#917d5cff1cf57e2555426b6dd8bf59dc3b7f0901"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.8.0#e849dc8921d2a48bec915f1a7c02f8988721022d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1269,7 +1269,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components#917d5cff1cf57e2555426b6dd8bf59dc3b7f0901"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.8.0#e849dc8921d2a48bec915f1a7c02f8988721022d"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "kbs_protocol"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components#917d5cff1cf57e2555426b6dd8bf59dc3b7f0901"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.8.0#e849dc8921d2a48bec915f1a7c02f8988721022d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2464,6 +2464,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
+ "tokio",
  "url",
  "zeroize",
 ]
@@ -3614,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "resource_uri"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components#917d5cff1cf57e2555426b6dd8bf59dc3b7f0901"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.8.0#e849dc8921d2a48bec915f1a7c02f8988721022d"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "as-types"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git#871ae511286bc08bf0086c572f7ba96ed17662f3"
+source = "git+https://github.com/confidential-containers/attestation-service.git?tag=v0.8.0#e050dd8c3077abc0caa42fedab7dc0b5dc42c2d9"
 dependencies = [
  "kbs-types",
  "serde",
@@ -502,7 +502,7 @@ dependencies = [
 [[package]]
 name = "attestation-service"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-service.git#871ae511286bc08bf0086c572f7ba96ed17662f3"
+source = "git+https://github.com/confidential-containers/attestation-service.git?tag=v0.8.0#e050dd8c3077abc0caa42fedab7dc0b5dc42c2d9"
 dependencies = [
  "anyhow",
  "as-types",
@@ -517,9 +517,11 @@ dependencies = [
  "chrono",
  "codicon",
  "csv-rs",
+ "ear",
  "eventlog-rs",
  "futures",
  "hex",
+ "jsonwebtoken",
  "jwt",
  "kbs-types",
  "lazy_static",
@@ -887,6 +889,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-codec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e083a023562b37c52837e850131a51b1154cceb9d149f41ee3d386737b140f46"
+dependencies = [
+ "byteorder",
+ "libc",
+]
+
+[[package]]
 name = "cbor-diag"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,7 +907,7 @@ dependencies = [
  "bs58",
  "chrono",
  "data-encoding",
- "half",
+ "half 2.3.1",
  "nom",
  "num-bigint",
  "num-rational",
@@ -943,6 +955,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -1169,6 +1208,17 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cose-rust"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f221b4189b72ce93755b7fa1495d1741cc330bbd9698d3032562811698e3ab84"
+dependencies = [
+ "cbor-codec",
+ "openssl",
+ "rand",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1440,6 +1490,23 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "ear"
+version = "0.1.0"
+source = "git+https://github.com/veraison/rust-ear?rev=cc6ea53#cc6ea5318b91f3038e337bdbaad0e9fb0fa2af2a"
+dependencies = [
+ "base64 0.21.4",
+ "ciborium",
+ "cose-rust",
+ "hex",
+ "jsonwebtoken",
+ "openssl",
+ "phf",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "ecdsa"
@@ -1856,6 +1923,12 @@ dependencies = [
 
 [[package]]
 name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
@@ -2268,9 +2341,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.4",
+ "pem",
  "ring 0.16.20",
  "serde",
  "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -2844,6 +2919,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.1.6+3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +2935,7 @@ checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2983,6 +3068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3153,49 @@ checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
  "indexmap 2.0.2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4085,6 +4222,24 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /usr/src/kbs
 COPY . .
 
 ARG KBS_FEATURES=coco-as-builtin,rustls,resource,opa
-RUN cargo install --path src/kbs --no-default-features --features ${KBS_FEATURES}
+RUN cargo install --locked --path src/kbs --no-default-features --features ${KBS_FEATURES}
 
 FROM debian:stable-slim
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -45,7 +45,7 @@ make install-kbs
 
 Start KBS with HTTP server:
 ```shell
-kbs --socket 127.0.0.1:50000 --insecure-http --auth-public-key config/public.pub
+kbs --config-file config/kbs-config.toml
 ```
 
 If you want start KBS with HTTPS server, use `--private-key` and `--certificate`

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -26,8 +26,8 @@ actix-web-httpauth = "0.8.0"
 aes-gcm = { version = "0.10.1", optional = true }
 anyhow.workspace = true
 async-trait.workspace = true
-as-types = { git = "https://github.com/confidential-containers/attestation-service.git" }
-attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", default-features = false, optional = true }
+as-types = { git = "https://github.com/confidential-containers/attestation-service.git", tag = "v0.8.0" }
+attestation-service = { git = "https://github.com/confidential-containers/attestation-service.git", tag = "v0.8.0", default-features = false, optional = true }
 base64.workspace = true
 cfg-if.workspace = true
 clap = { version = "4.3.21", features = ["derive", "env"] }

--- a/src/api/src/resource/mod.rs
+++ b/src/api/src/resource/mod.rs
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::*;
-use local_fs::LocalFs;
-pub use local_fs::LocalFsRepoDesc;
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;
@@ -72,7 +70,7 @@ impl RepositoryConfig {
                     fs::create_dir_all(format!("{}/default", &dir_path))?;
                 }
 
-                Ok(Arc::new(RwLock::new(LocalFs::new(desc)?))
+                Ok(Arc::new(RwLock::new(local_fs::LocalFs::new(desc)?))
                     as Arc<RwLock<dyn Repository + Send + Sync>>)
             }
         }

--- a/tools/client/Cargo.toml
+++ b/tools/client/Cargo.toml
@@ -14,14 +14,14 @@ path = "src/main.rs"
 
 [dependencies]
 # TODO: change it to "0.8.0", once released.
-as-types = { git = "https://github.com/confidential-containers/attestation-service.git" }
+as-types = { git = "https://github.com/confidential-containers/attestation-service.git", tag = "v0.8.0", default-features = false }
 anyhow.workspace = true
 api-server.workspace = true
 base64.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }
 env_logger.workspace = true
 jwt-simple = "0.11.4"
-kbs_protocol = { git = "https://github.com/confidential-containers/guest-components" }
+kbs_protocol = { git = "https://github.com/confidential-containers/guest-components", default-features = false }
 log.workspace = true
 reqwest = { version = "0.11.18", default-features = false, features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/tools/client/Cargo.toml
+++ b/tools/client/Cargo.toml
@@ -21,7 +21,7 @@ base64.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }
 env_logger.workspace = true
 jwt-simple = "0.11.4"
-kbs_protocol = { git = "https://github.com/confidential-containers/guest-components" }
+kbs_protocol = { git = "https://github.com/confidential-containers/guest-components", tag = "v0.8.0" }
 log.workspace = true
 reqwest = { version = "0.11.18", default-features = false, features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/tools/client/Cargo.toml
+++ b/tools/client/Cargo.toml
@@ -21,7 +21,7 @@ base64.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }
 env_logger.workspace = true
 jwt-simple = "0.11.4"
-kbs_protocol = { git = "https://github.com/confidential-containers/guest-components", default-features = false }
+kbs_protocol = { git = "https://github.com/confidential-containers/guest-components" }
 log.workspace = true
 reqwest = { version = "0.11.18", default-features = false, features = ["cookies", "json"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Let's wait guest-components to be released and then change the rev insode `tools/client`.

Step 10 in https://github.com/confidential-containers/confidential-containers/issues/145