### PR TITLE
attestation-agent: fail fast on broken AMD certs

### DIFF
--- a/attestation-service/verifier/src/lib.rs
+++ b/attestation-service/verifier/src/lib.rs
@@ -28,7 +28,8 @@ pub fn to_verifier(tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
         Tee::AzSnpVtpm => {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "az-snp-vtpm-verifier")] {
-                    Ok(Box::<az_snp_vtpm::AzSnpVtpm>::default() as Box<dyn Verifier + Send + Sync>)
+                    let verifier = az_snp_vtpm::AzSnpVtpm::new()?;
+                    Ok(Box::new(verifier) as Box<dyn Verifier + Send + Sync>)
                 } else {
                     bail!("feature `az-snp-vtpm-verifier` is not enabled for `verifier` crate.")
                 }
@@ -46,7 +47,8 @@ pub fn to_verifier(tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
         Tee::Snp => {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "snp-verifier")] {
-                    Ok(Box::<snp::Snp>::default() as Box<dyn Verifier + Send + Sync>)
+                    let verifier = snp::Snp::new()?;
+                    Ok(Box::new(verifier) as Box<dyn Verifier + Send + Sync>)
                 } else {
                     bail!("feature `snp-verifier` is not enabled for `verifier` crate.")
                 }


### PR DESCRIPTION
Currently the milan vendor certs from AMD are bundled and parsed each time there is verification in process attestation. While this should never fail, we cannot `panic!` as it would impact healthy TEE implementations.

As an alternative we can fail fast on init of the verifier, indicating a problem at an earlier point. We also don't need to process the raw bytes multiple times, the vendor certs can be cached once parsed.

This impacts both SNP verifiers (`snp` + `az-snp-vtpm`)