### PR TITLE
Cca: Get the evidence from EAR (EAT Attesation Result)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
  "prost",
  "rand",
  "reqwest",
- "rsa 0.9.5",
+ "rsa 0.9.6",
  "rstest",
  "rustls 0.20.9",
  "rustls-pemfile",
@@ -538,7 +538,7 @@ dependencies = [
  "prost",
  "rand",
  "reference-value-provider-service",
- "rsa 0.9.5",
+ "rsa 0.9.6",
  "rstest",
  "serde",
  "serde_json",
@@ -864,15 +864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,25 +907,6 @@ checksum = "e083a023562b37c52837e850131a51b1154cceb9d149f41ee3d386737b140f46"
 dependencies = [
  "byteorder",
  "libc",
-]
-
-[[package]]
-name = "cbor-diag"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
-dependencies = [
- "bs58",
- "chrono",
- "data-encoding",
- "half 2.3.1",
- "nom",
- "num-bigint",
- "num-rational",
- "num-traits",
- "separator",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -1001,7 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
- "half 1.8.2",
+ "half",
 ]
 
 [[package]]
@@ -1215,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1225,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cose-rust"
@@ -1281,12 +1253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto"
 version = "0.1.0"
 source = "git+https://github.com/confidential-containers/guest-components?rev=8dd91e0#8dd91e0084805b916e5c27fb573a1de355de0be1"
@@ -1297,7 +1263,7 @@ dependencies = [
  "ctr",
  "kbs-types",
  "rand",
- "rsa 0.9.5",
+ "rsa 0.9.6",
  "serde",
  "serde_json",
  "sha2",
@@ -1455,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
 ]
@@ -1553,7 +1519,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature 2.2.0",
- "spki 0.7.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1978,16 +1944,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "half"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2610,9 +2566,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "local-channel"
@@ -2839,18 +2795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3332,7 +3276,7 @@ checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der 0.7.8",
  "pkcs8 0.10.2",
- "spki 0.7.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3370,7 +3314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.8",
- "spki 0.7.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3808,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6c4b23d99685a1408194da11270ef8e9809aff951cc70ec9b17350b087e474"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
  "const-oid",
  "digest",
@@ -3822,7 +3766,7 @@ dependencies = [
  "rand_core",
  "sha2",
  "signature 2.2.0",
- "spki 0.7.2",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -3907,15 +3851,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4108,12 +4052,6 @@ checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "separator"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
@@ -4441,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der 0.7.8",
@@ -5181,7 +5119,6 @@ dependencies = [
  "base64 0.21.5",
  "bincode",
  "byteorder",
- "cbor-diag",
  "cfg-if",
  "codicon",
  "csv-rs",
@@ -5581,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -5591,9 +5528,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/attestation-service/verifier/Cargo.toml
+++ b/attestation-service/verifier/Cargo.toml
@@ -11,7 +11,7 @@ sgx-verifier = [ "scroll", "sgx-dcap-quoteverify-rs" ]
 az-snp-vtpm-verifier = [ "az-snp-vtpm", "sev", "snp-verifier" ]
 snp-verifier = [ "asn1-rs", "openssl", "sev", "x509-parser" ]
 csv-verifier = [ "openssl", "csv-rs", "codicon" ]
-cca-verifier = [ "cbor-diag", "veraison-apiclient" ]
+cca-verifier = [ "ear", "veraison-apiclient" ]
 
 [dependencies]
 anyhow.workspace = true
@@ -21,7 +21,6 @@ az-snp-vtpm = { version = "0.4", default-features = false, features = ["verifier
 base64 = "0.21"
 bincode = "1.3.3"
 byteorder = "1"
-cbor-diag = { version = "0.1.11", optional = true }
 cfg-if = "1.0.0"
 codicon = { version = "3.0", optional = true }
 # TODO: change it to "0.1", once released.
@@ -40,7 +39,7 @@ sev = { version = "1.2.0", features = ["openssl", "snp"], optional = true }
 sgx-dcap-quoteverify-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.16", optional = true }
 strum.workspace = true
 veraison-apiclient = { git = "https://github.com/chendave/rust-apiclient", branch = "token", optional = true }
-ear = { git = "https://github.com/veraison/rust-ear", rev = "cc6ea53" }
+ear = { git = "https://github.com/veraison/rust-ear", rev = "cc6ea53", optional = true }
 x509-parser = { version = "0.14.0", optional = true }
 
 [build-dependencies]

--- a/attestation-service/verifier/src/cca/mod.rs
+++ b/attestation-service/verifier/src/cca/mod.rs
@@ -8,12 +8,11 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use base64::Engine;
 use core::result::Result::Ok;
-use ear::Ear;
+use ear::{Ear, RawValue};
 use jsonwebtoken::{self as jwt};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
-use std::str;
+use std::{collections::BTreeMap, str};
 use veraison_apiclient::*;
 
 const VERAISON_ADDR: &str = "VERAISON_ADDR";
@@ -23,23 +22,42 @@ const MEDIA_TYPE: &str = "application/eat-collection; profile=http://arm.com/CCA
 #[derive(Debug, Default)]
 pub struct CCA {}
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct SwComponent {
+    pub measurement_type: String,
+    pub measurement_value: String,
+    pub version: String,
+    pub signer_id: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CcaPlatformClaims {
+    pub cca_platform_challenge: String,
+    pub cca_platform_sw_components: Vec<SwComponent>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RealmClaims {
+    pub cca_realm_personalization_value: String,
+    pub cca_realm_initial_measurement: String,
+    pub cca_realm_extensible_measurements: Vec<String>,
+    pub cca_realm_hash_algo_id: String,
+    pub cca_realm_public_key_hash_algo_id: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Evidence {
+    realm: RealmClaims,
+    platform: CcaPlatformClaims,
+}
+
 #[derive(Serialize, Deserialize)]
 struct CcaEvidence {
     /// CCA token
     token: Vec<u8>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct RealmToken {
-    //cca_realm_personalization_value: String,
-    cca_realm_initial_measurement: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct Evidence {
-    cca_realm_delegated_token: RealmToken,
 }
 
 fn my_evidence_builder(
@@ -47,8 +65,8 @@ fn my_evidence_builder(
     accept: &[String],
     token: Vec<u8>,
 ) -> Result<(Vec<u8>, String), veraison_apiclient::Error> {
-    log::info!("server challenge: {:?}", nonce);
-    log::info!("acceptable media types: {:#?}", accept);
+    info!("server challenge: {:?}", nonce);
+    info!("acceptable media types: {:#?}", accept);
     // TODO: Get the CCA media type from the slice of `accept`.
     Ok((token, MEDIA_TYPE.to_string()))
 }
@@ -104,7 +122,7 @@ impl Verifier for CCA {
         let n = Nonce::Value(expected_report_data.clone());
         let result = match cr.run(n, my_evidence_builder, token.clone()).await {
             Err(e) => {
-                log::error!("Error: {}", e);
+                error!("Error: {}", e);
                 bail!("CCA Attestation failed with error: {:?}", e);
             }
             Ok(attestation_result) => attestation_result,
@@ -118,7 +136,7 @@ impl Verifier for CCA {
             .context("decrypt the ear with the decoding key")?;
 
         let ear_nonce = plain_ear.nonce.context("get nonce from ear")?;
-        let nonce_byte = base64::engine::general_purpose::URL_SAFE
+        let nonce_byte = base64::engine::general_purpose::STANDARD
             .decode(ear_nonce.to_string())
             .context("decode nonce byte from ear")?;
 
@@ -126,29 +144,32 @@ impl Verifier for CCA {
             bail!("report data is different from that in ear's session nonce");
         }
 
+        let cca_mod = match plain_ear.submods.get("CCA_SSD_PLATFORM") {
+            Some(value) => value,
+            None => bail!("no entry found for CCA_SSD_PLATFORM"),
+        };
+        let evidence = &cca_mod.annotated_evidence;
+
         if let InitDataHash::Value(_) = expected_init_data_hash {
             warn!("CCA currently does not support parse `cca_realm_personalization_value`. Init data hash check skipped.");
         }
 
-        // NOTE: The tcb returned is actually an empty `Evidence`, the code here is just a show case the parse of the CCA token
-        // to get the tcb is possible, but this is not actually fully implemented due to the below reasons:
-        // 1. CCA validation by the Verasion has some overlapping with the RVPS, the similar validation has been done by the Verasion already.
-        // 2. Each of key of the CCA token layout after the parse is an int from hex, it cannot be converted into a json easily without
-        // manually manipulation, which is dirty and complex, we can hold this for an while and see if the type of key can be redefined as String.
-        let tcb = parse_cca_token(token)?;
+        // NOTE: CCA validation by the Verasion has some overlapping with the RVPS, the similar validation has been done by the Verasion already.
+        // The generation of CCA evidence here is to align with other verifier, e.g. TDX, and to support RVPS if that is the case of future planning.
+        let tcb = parse_cca_evidence(evidence)?;
         // Return Evidence parsed claim
         cca_generate_parsed_claim(tcb).map_err(|e| anyhow!("error from CCA Verifier: {:?}", e))
     }
 }
 
-/// The expected token layout looks like below,
+/// The expected evidence layout looks like below,
 ///
 /// In short:
 /// {
-/// "cca-platform-token" (44234): {
+/// "platform": {
 ///     ...
 ///   },
-/// "cca-realm-delegated-token" (44241): {
+/// "realm": {
 ///     ...
 ///   }
 /// }
@@ -156,130 +177,81 @@ impl Verifier for CCA {
 /// and the details for each of them is listed here:
 ///
 /// {
-///     265_1: "http://arm.com/CCA-SSD/1.0.0",
-///     10: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///     2396_1: h'7f454c4602010100000000000000000003003e000100000050580000000000004000000000000000a0030200000000000000000040003800090040001c001b00',
-///     256_1: h'0107060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///     2401_1: h'0107060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///     2395_1: 12291_1,
-///     2402_1: "sha-256",
-///     2399_1: [
-///         {
-///             1: "BL",
-///             5: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///             4: "3.4.2",
-///             2: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///             6: "sha-256",
-///         },
-///         {
-///             1: "M1",
-///             5: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///             4: "1.2",
-///             2: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///         },
-///         {
-///             1: "M2",
-///             5: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///             4: "1.2.3",
-///             2: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///         },
-///         {
-///             1: "M3",
-///             5: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///             4: "1",
-///             2: h'07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918',
-///         },
-///     ],
-///     2400_1: "whatever.com",
+///    "platform":{
+///       "cca-platform-challenge":"tZc8touqn8VVWHhrfsZ/aeQN9bpaqSHNDCf0BYegEeo=",
+///       "cca-platform-config":"AQcGBQQDAgEADw4NDAsKCQgXFhUUExIREB8eHRwbGhkY",
+///       "cca-platform-hash-algo-id":"sha-256",
+///       "cca-platform-implementation-id":"f0VMRgIBAQAAAAAAAAAAAAMAPgABAAAAUFgAAAAAAAA=",
+///       "cca-platform-instance-id":"AQcGBQQDAgEADw4NDAsKCQgXFhUUExIREB8eHRwbGhkY",
+///       "cca-platform-lifecycle":12291,
+///       "cca-platform-profile":"http://arm.com/CCA-SSD/1.0.0",
+///       "cca-platform-service-indicator":"whatever.com",
+///       "cca-platform-sw-components":[
+///          {
+///             "measurement-description":"TF-M_SHA256MemPreXIP",
+///             "measurement-type":"BL",
+///             "measurement-value":"BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+///             "signer-id":"BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+///             "version":"3.4.2"
+///          },
+///          {
+///             "measurement-type":"M1",
+///             "measurement-value":"BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+///             "signer-id":"BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+///             "version":"1.2"
+///          },
+///          {
+///             "measurement-type":"M2",
+///             "measurement-value":"BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+///             "signer-id":"BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+///             "version":"1.2.3"
+///          },
+///          {
+///             "measurement-type":"M3",
+///             "measurement-value":"BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+///             "signer-id":"BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+///             "version":"1"
+///          }
+///       ]
+///    },
+///    "realm":{
+///       "cca-realm-challenge":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+///       "cca-realm-extensible-measurements":[
+///          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+///          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+///          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+///          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+///       ],
+///       "cca-realm-hash-algo-id":"sha-256",
+///       "cca-realm-initial-measurement":"EJHTwpx6vz58Z4/NjKCnmOse6cirEeEbPq06H/xIXUw=",
+///       "cca-realm-personalization-value":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+///       "cca-realm-public-key":"BHb5iAkb5YXtQYAa7Pq4WFSMYwV+FrDmdhILvQ0vnCngVsXUGgEw65whUXiZ3CMUayjhsGK9PqSzFf0hnxy7Uoy250ykm+Fnc3NPYaHKYQMbK789kY8vlP/EIo5QkZVErg==",
+///       "cca-realm-public-key-hash-algo-id":"sha-256"
+///    }
 /// }
-/// {
-///     10: h'00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-///     44235_1: h'00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-///     44237_1: h'0476f988091be585ed41801aecfab858548c63057e16b0e676120bbd0d2f9c29e056c5d41a0130eb9c21517899dc23146b28e1b062bd3ea4b315fd219f1cbb528cb6e74ca49be16773734f61a1ca61031b2bbf3d918f2f94ffc4228e50919544ae',
-///     44236_1: "sha-256",
-///     44240_1: "sha-256",
-///     44238_1: h'75a1fbc79a7d20a5ff843b914dfd8093d40cd07dd633401c8c42d697be224801',
-///     44239_1: [
-///         h'0000000000000000000000000000000000000000000000000000000000000000',
-///         h'0000000000000000000000000000000000000000000000000000000000000000',
-///         h'0000000000000000000000000000000000000000000000000000000000000000',
-///         h'0000000000000000000000000000000000000000000000000000000000000000',
-///     ],
-/// }
-fn parse_cca_token(token: Vec<u8>) -> Result<Evidence> {
-    let evidence = Evidence {
-        cca_realm_delegated_token: RealmToken {
-            cca_realm_initial_measurement: "".to_string(),
-        },
-    };
+/// NOTE: each of the value are base64 encoded hex value.
+fn parse_cca_evidence(evidence_map: &BTreeMap<String, RawValue>) -> Result<Evidence> {
+    let mut evidence = Evidence::default();
+    let platfrom = evidence_map
+        .get("platform")
+        .context("get platform evidence from the cca evidence map")?;
+    let output = serde_json::to_string(platfrom)?;
+    let p: CcaPlatformClaims = serde_json::from_str(output.as_str())?;
+    evidence.platform = p;
 
-    // NOTE: For some corner case, the date cannot be parsed to token correctly but the token
-    // can be validated successfully by the CCA verifier e.g. `Err` value: Todo("Remaining bytes (00)")'
-    // Instead of throwing an error, just print it out in this case.
-    let mut di = match cbor_diag::parse_bytes(token) {
-        Ok(di) => di,
-        Err(err) => {
-            log::info!("Error: {:?}", err);
-            return Ok(evidence);
-        }
-    };
-
-    if let cbor_diag::DataItem::Tag {
-        tag: _,
-        bitwidth: _,
-        value,
-    } = di
-    {
-        di = *value;
-    }
-
-    if let cbor_diag::DataItem::Map { data, .. } = di {
-        for item in data {
-            let cbor_diag::DataItem::ByteString(t) = item.1 else {
-                anyhow::bail!("DateItem is not a ByteString");
-            };
-
-            let val = cbor_diag::parse_bytes(t.data)?;
-
-            let cbor_diag::DataItem::Tag { value, .. } = val else {
-                anyhow::bail!("DateItem is not a Tag");
-            };
-
-            let cbor_diag::DataItem::Array { data, .. } = *value else {
-                anyhow::bail!("DateItem is not a Array");
-            };
-
-            if let cbor_diag::DataItem::ByteString(cose) = data
-                .get(2)
-                .ok_or_else(|| anyhow!("Cannot get raw bytes from token"))?
-            {
-                let v = &cose.data;
-                match cbor_diag::parse_bytes(v) {
-                    Ok(claims) => {
-                        info!("{}", claims.to_diag_pretty());
-                    }
-                    Err(e) => {
-                        error!("Error parsing claims: {}", e);
-                    }
-                }
-            };
-        }
-    }
+    let realm = evidence_map
+        .get("realm")
+        .context("get realm evidence from the cca evidence map")?;
+    let output = serde_json::to_string(realm)?;
+    let r: RealmClaims = serde_json::from_str(output.as_str())?;
+    evidence.realm = r;
 
     Ok(evidence)
 }
 
 fn cca_generate_parsed_claim(tcb: Evidence) -> Result<TeeEvidenceParsedClaim> {
-    let mut claim_map = Map::new();
-
-    claim_map.insert(
-        "cca-realm-initial-measurement".to_string(),
-        serde_json::Value::String(tcb.cca_realm_delegated_token.cca_realm_initial_measurement),
-    );
-
-    log::info!("\nParsed Evidence claims map: \n{:?}\n", &claim_map);
-
-    Ok(Value::Object(claim_map) as TeeEvidenceParsedClaim)
+    let v = serde_json::to_value(tcb).context("build json value from the cca evidence")?;
+    Ok(v as TeeEvidenceParsedClaim)
 }
 
 #[cfg(test)]
@@ -289,7 +261,7 @@ mod tests {
 
     #[test]
     fn test_cca_generate_parsed_claim() {
-        let s = fs::read("./test_data/cca-claims.json").unwrap();
+        let s = fs::read("../test_data/cca-claims.json").unwrap();
         let evidence = String::from_utf8_lossy(&s);
         let tcb = serde_json::from_str::<Evidence>(&evidence).unwrap();
         let parsed_claim = cca_generate_parsed_claim(tcb);

--- a/attestation-service/verifier/test_data/cca-claims.json
+++ b/attestation-service/verifier/test_data/cca-claims.json
@@ -1,20 +1,23 @@
 {
-  "cca-platform-token": {
+  "platform": {
     "cca-platform-profile": "http://arm.com/CCA-SSD/1.0.0",
     "cca-platform-implementation-id": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
     "cca-platform-instance-id": "AQICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC",
+    "cca-platform-challenge": "AQICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC",
     "cca-platform-config": "AQID",
     "cca-platform-lifecycle": 12288,
     "cca-platform-sw-components": [
       {
+	"measurement-type":"BL",
         "measurement-value": "AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=",
-        "signer-id": "BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ="
+        "signer-id": "BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ=",
+	"version":"3.4.2"
       }
     ],
     "cca-platform-service-indicator": "https://veraison.example/v1/challenge-response",
     "cca-platform-hash-algo-id": "sha-256"
   },
-  "cca-realm-delegated-token": {
+  "realm": {
     "cca-realm-challenge": "QUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQg==",
     "cca-realm-personalization-value": "QURBREFEQURBREFEQURBREFEQURBREFEQURBREFEQURBREFEQURBREFEQURBREFEQURBREFEQURBREFEQURBRA==",
     "cca-realm-initial-measurement": "Q0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQw==",


### PR DESCRIPTION
CCA validation by the Verasion has some overlapping with the RVPS, the similar validation has been done by the Verasion already. So the validation of evidence in CoCo is not needed in theory.

The parse of the CCA token here is to align with other verifier, e.g. TDX, and to support RVPS if that is the case of future planning.

NOTE that each of the value we get from EAR is base64 encoded hex value. So, the reference value that are registered for RVPS are expected to be base64 encoded hex value as well.

[1] https://datatracker.ietf.org/doc/draft-ietf-rats-ar4si/