### PR TITLE
Rename Amber to Intel Trust Authority

### DIFF
--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -72,9 +72,9 @@ jobs:
       working-directory: kbs
       run: make COCO_AS_INTEGRATE_TYPE=grpc
 
-    - name: build KBS with amber AS mode
+    - name: build KBS for Intel Trust Authority
       working-directory: kbs
-      run: make AS_TYPE=amber-as
+      run: make AS_TYPE=intel-trust-authority-as
 
     - name: Lint
       working-directory: kbs

--- a/kbs/README.md
+++ b/kbs/README.md
@@ -48,7 +48,7 @@ Default value is `rustls`
 - `POLICY_ENGINE`: Can be `opa`.
 Specify the resource policy engine type of KBS.
 If not set this parameter, KBS will not integrate resource policy engine.
-- `AS_TYPES`: can be `coco-as` or `amber-as`.
+- `AS_TYPES`: can be `coco-as` or `intel-trust-authority-as`.
 Specify the Attestation Service type KBS relies on.
 - `COCO_AS_INTEGRATION_TYPE`: can be `grpc` or `builtin`. This parameter only takes effect when `AS_TYPES=coco-as`.
 Specify the integration mode of CoCo Attestation Service.

--- a/kbs/config/kbs-config-amber.toml
+++ b/kbs/config/kbs-config-amber.toml
@@ -1,7 +1,0 @@
-insecure_http = true
-insecure_api = true
-
-[amber_config]
-base_url = "https://amber.com"
-api_key = "tBfd5kKX2x9ahbodKV1..."
-certs_file = "/etc/amber/amber-certs.txt"

--- a/kbs/config/kbs-config-intel-trust-authority.toml
+++ b/kbs/config/kbs-config-intel-trust-authority.toml
@@ -1,0 +1,7 @@
+insecure_http = true
+insecure_api = true
+
+[intel_trust_authority_config]
+base_url = "https://api.trustauthority.intel.com"
+api_key = "tBfd5kKX2x9ahbodKV1..."
+certs_file = "/etc/intel-trust-authority-certs.txt"

--- a/kbs/docker/Dockerfile.intel-trust-authority
+++ b/kbs/docker/Dockerfile.intel-trust-authority
@@ -10,7 +10,7 @@ RUN tar -C /usr/local -xzf go1.20.1.linux-amd64.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Build and Install KBS
-RUN cargo install --path kbs/src/kbs --no-default-features --features amber-as,rustls,resource,opa
+RUN cargo install --path kbs/src/kbs --no-default-features --features intel-trust-authority-as,rustls,resource,opa
 
 FROM ubuntu:22.04
 

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -91,18 +91,20 @@ This section is **optional**. When omitted, a default configuration is used.
 |-----------|--------|------------------------------|----------|--------------------------|
 | `as_addr` | String | Attestation service address. | No       | `http://127.0.0.1:50004` |
 
-### Amber Attestation
+### Intel Trust Authority (formerly known as Amber)
 
-The following properties can be set under the `amber_config` section.
+The following properties can be set under the `intel_trust_authority_config` section.
 
->This section is available only when the `amber-as` feature is enabled.
+>This section is available only when the `intel-trust-authority-as` feature is enabled.
 
 | Property                 | Type    | Description                                                                            | Required                | Default |
 |--------------------------|---------|----------------------------------------------------------------------------------------|-------------------------|---------|
-| `base_url`               | String  | URL of the Amber API.                                                                  | Yes                     | -       |
-| `api_key`                | String  | Amber API key.                                                                         | Yes                     | -       |
-| `certs_file`             | String  | Path to a JWKS file to be used for Amber token verification.                           | Yes                     | -       |
-| `allow_unmatched_policy` | Boolean | Determines whether to ignore the `amber_unmatched_policy_ids` field in an Amber token. | No                      | false   |
+| `base_url`               | String  | Intel Trust Authority API URL.                                                         | Yes                     | -       |
+| `api_key`                | String  | Intel Trust Authority API key.                                                         | Yes                     | -       |
+| `certs_file`             | String  | Path to an Intel Trust Authority certificates JWKS file used for token verification.   | Yes                     | -       |
+| `allow_unmatched_policy` | Boolean | Determines whether to ignore the `policy_ids_unmatched` token claim.                   | No                      | false   |
+
+Detailed [documentation](https://docs.trustauthority.intel.com).
 
 ### Policy Engine Configuration
 
@@ -150,7 +152,7 @@ dir_path = "/opt/confidential-containers/kbs/repository"
 as_addr = "http://127.0.0.1:50004"
 ```
 
-Running with Amber attestation service:
+Running with Intel Trust Authority attestation service:
 
 ```toml
 insecure_http = true
@@ -160,10 +162,10 @@ insecure_api = true
 type = "LocalFs"
 dir_path = "/opt/confidential-containers/kbs/repository"
 
-[amber_config]
-base_url = "https://amber.com"
+[intel_trust_authority_config]
+base_url = "https://api.trustauthority.intel.com"
 api_key = "tBfd5kKX2x9ahbodKV1..."
-certs_file = "/etc/amber/amber-certs.txt"
+certs_file = "/etc/intel-trust-authority-certs.txt"
 allow_unmatched_policy = true
 ```
 

--- a/kbs/src/api/Cargo.toml
+++ b/kbs/src/api/Cargo.toml
@@ -16,7 +16,7 @@ coco-as = ["as"]
 coco-as-builtin = ["coco-as", "attestation-service/default"]
 coco-as-builtin-no-verifier = ["coco-as", "attestation-service/rvps-builtin"]
 coco-as-grpc = ["coco-as", "tonic", "tonic-build", "prost"]
-amber-as = ["as", "reqwest", "jsonwebtoken"]
+intel-trust-authority-as = ["as", "reqwest", "jsonwebtoken"]
 rustls = ["actix-web/rustls", "dep:rustls", "dep:rustls-pemfile"]
 openssl = ["actix-web/openssl", "dep:openssl"]
 

--- a/kbs/src/api/src/attestation/mod.rs
+++ b/kbs/src/api/src/attestation/mod.rs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "amber-as")]
-use amber::AmberConfig;
 use anyhow::*;
 use async_trait::async_trait;
 #[cfg(any(feature = "coco-as-builtin", feature = "coco-as-builtin-no-verifier"))]
 use attestation_service::config::Config as AsConfig;
 #[cfg(feature = "coco-as-grpc")]
 use coco::grpc::GrpcConfig;
+#[cfg(feature = "intel-trust-authority-as")]
+use intel_trust_authority::IntelTrustAuthorityConfig;
 use kbs_types::Tee;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -18,8 +18,8 @@ use tokio::sync::Mutex;
 #[allow(missing_docs)]
 pub mod coco;
 
-#[cfg(feature = "amber-as")]
-pub mod amber;
+#[cfg(feature = "intel-trust-authority-as")]
+pub mod intel_trust_authority;
 
 /// Interface for Attestation Services.
 ///
@@ -60,10 +60,11 @@ impl AttestationService {
     }
 
     /// Create and initialize AttestationService.
-    #[cfg(feature = "amber-as")]
-    pub fn new(config: &AmberConfig) -> Result<Self> {
-        let attestation_service: Arc<Mutex<dyn Attest>> =
-            Arc::new(Mutex::new(amber::Amber::new(config)?));
+    #[cfg(feature = "intel-trust-authority-as")]
+    pub fn new(config: &IntelTrustAuthorityConfig) -> Result<Self> {
+        let attestation_service: Arc<Mutex<dyn Attest>> = Arc::new(Mutex::new(
+            intel_trust_authority::IntelTrustAuthority::new(config)?,
+        ));
 
         Ok(Self(attestation_service))
     }

--- a/kbs/src/api/src/config.rs
+++ b/kbs/src/api/src/config.rs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "amber-as")]
-use crate::attestation::amber::AmberConfig;
 #[cfg(feature = "coco-as-grpc")]
 use crate::attestation::coco::grpc::GrpcConfig;
+#[cfg(feature = "intel-trust-authority-as")]
+use crate::attestation::intel_trust_authority::IntelTrustAuthorityConfig;
 #[cfg(feature = "policy")]
 use crate::policy_engine::PolicyEngineConfig;
 #[cfg(feature = "resource")]
@@ -50,9 +50,9 @@ pub struct KbsConfig {
     #[cfg(feature = "coco-as-grpc")]
     pub grpc_config: Option<GrpcConfig>,
 
-    /// Configuration for Amber attestation.
-    #[cfg(feature = "amber-as")]
-    pub amber_config: AmberConfig,
+    /// Configuration for Intel Trust Authority attestation.
+    #[cfg(feature = "intel-trust-authority-as")]
+    pub intel_trust_authority_config: IntelTrustAuthorityConfig,
 
     /// Socket addresses (IP:port) to listen on, e.g. 127.0.0.1:8080.
     pub sockets: Vec<SocketAddr>,

--- a/kbs/src/kbs/Cargo.toml
+++ b/kbs/src/kbs/Cargo.toml
@@ -14,7 +14,7 @@ opa = ["api-server/opa"]
 coco-as-builtin = ["as", "api-server/coco-as-builtin"]
 coco-as-builtin-no-verifier = ["as", "api-server/coco-as-builtin-no-verifier"]
 coco-as-grpc = ["as", "api-server/coco-as-grpc"]
-amber-as = ["as", "api-server/amber-as"]
+intel-trust-authority-as = ["as", "api-server/intel-trust-authority-as"]
 rustls = ["api-server/rustls"]
 openssl = ["api-server/openssl"]
 

--- a/kbs/src/kbs/src/main.rs
+++ b/kbs/src/kbs/src/main.rs
@@ -46,10 +46,10 @@ async fn main() -> Result<()> {
                 AttestationService::new(&kbs_config.as_config.unwrap_or_default()).await?
             } else if #[cfg(feature = "coco-as-grpc")] {
                 AttestationService::new(&kbs_config.grpc_config.unwrap_or_default()).await?
-            } else if #[cfg(feature = "amber-as")] {
-                AttestationService::new(&kbs_config.amber_config)?
+            } else if #[cfg(feature = "intel-trust-authority-as")] {
+                AttestationService::new(&kbs_config.intel_trust_authority_config)?
             } else {
-                compile_error!("Please enable at least one of the following features: `coco-as-builtin`, `coco-as-builtin-no-verifier`, `coco-as-grpc` or `amber-as` to continue.");
+                compile_error!("Please enable at least one of the following features: `coco-as-builtin`, `coco-as-builtin-no-verifier`, `coco-as-grpc` or `intel-trust-authority-as` to continue.");
             }
         }
     };


### PR DESCRIPTION
Amber is officially called Intel Trust Authority and the code name is not to be used anymore.

Fixes: #87