### PR TITLE
KBS: Optimize performance and memory usage

### DIFF
--- a/kbs/src/api/src/http/attest.rs
+++ b/kbs/src/api/src/http/attest.rs
@@ -57,10 +57,12 @@ pub(crate) async fn attest(
         (session.tee(), session.nonce().to_string())
     };
 
+    let attestation_str = serde_json::to_string(&attestation)
+        .map_err(|e| Error::AttestationFailed(format!("serialize attestation failed : {e:?}")))?;
     let token = attestation_service
-        .verify(tee, &nonce, &serde_json::to_string(&attestation).unwrap())
+        .verify(tee, &nonce, &attestation_str)
         .await
-        .map_err(|e| Error::AttestationFailed(e.to_string()))?;
+        .map_err(|e| Error::AttestationFailed(format!("{e:?}")))?;
 
     let claims_b64 = token
         .split('.')

--- a/kbs/src/api/src/http/error.rs
+++ b/kbs/src/api/src/http/error.rs
@@ -27,9 +27,6 @@ pub enum Error {
     #[error("Attestation failed: {0}")]
     AttestationFailed(String),
 
-    #[error("Attestation claims get failed: {0}")]
-    AttestationClaimsGetFailed(String),
-
     #[error("Received illegal attestation claims: {0}")]
     AttestationClaimsParseFailed(String),
 

--- a/kbs/src/api/src/http/mod.rs
+++ b/kbs/src/api/src/http/mod.rs
@@ -10,7 +10,7 @@ use crate::policy_engine::PolicyEngine;
 #[cfg(feature = "resource")]
 use crate::resource::{set_secret_resource, Repository, ResourceDesc};
 #[cfg(feature = "as")]
-use crate::session::{Session, SessionMap, KBS_SESSION_ID};
+use crate::session::{SessionMap, KBS_SESSION_ID};
 #[cfg(feature = "resource")]
 use crate::token::AttestationTokenVerifier;
 use actix_web::Responder;


### PR DESCRIPTION
Currently we are using a global Mutex to protect the only one attestation service client from unsafe thread sync & send. This brings performance bottle neck.

This commit will create a temporary client object to handle the current attestation request, which can break the mutex.

Fixes #256