### PR TITLE
Fix dependency version when building container image

### DIFF
--- a/attestation-service/Dockerfile.as
+++ b/attestation-service/Dockerfile.as
@@ -22,7 +22,7 @@ RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key 
     apt-get update && apt-get install -y libtdx-attest-dev libsgx-dcap-quote-verify-dev
 
 # Build and Install gRPC attestation-service
-RUN cargo install --path attestation-service/bin/grpc-as
+RUN cargo install --locked --path attestation-service/bin/grpc-as
 
 
 FROM ubuntu:22.04


### PR DESCRIPTION
Everytime executing cargo build, the Cargo.lock will be updated. This will bring unexpected build error when the upstream of dependency updates. `-locked` parameter will help to fix the dependency version in Cargo.lock, thus prevent unexpected build error.

Fixes #260