### PR TITLE
kbs/tool: remove unless dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,6 @@ name = "kbs-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "api-server",
  "base64 0.21.5",
  "clap 4.4.10",
  "env_logger 0.10.1",

--- a/kbs/test/Makefile
+++ b/kbs/test/Makefile
@@ -44,8 +44,7 @@ resource-kbs:
 
 client:
 	cd $(PROJECT_DIR) && \
-	cargo build -p kbs-client --release \
-		--features api-server/coco-as-builtin,api-server/rustls && \
+	cargo build -p kbs-client --release && \
 	install -D --compare $(PROJECT_DIR)/../target/release/kbs-client $(CURDIR)/client
 
 .PHONY: bins

--- a/kbs/tools/client/Cargo.toml
+++ b/kbs/tools/client/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
-api-server.workspace = true
 base64.workspace = true
 clap = { version = "4.0.29", features = ["derive"] }
 env_logger.workspace = true


### PR DESCRIPTION
api-server is never used in client tool. Also if the dependency is included, the build process will fail because wrong feature configured.

cc @jialez0 