### PR TITLE
KBS/perf: promote the concurrency performance of KBS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,7 @@ dependencies = [
  "kbs-types",
  "lazy_static",
  "log",
+ "mobc",
  "openssl",
  "prost",
  "rand",
@@ -425,6 +426,7 @@ dependencies = [
  "rstest",
  "rustls 0.20.9",
  "rustls-pemfile",
+ "scc",
  "semver 1.0.20",
  "serde",
  "serde_json",
@@ -2618,6 +2620,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e52eb6380b6d2a10eb3434aec0885374490f5b82c8aaf5cd487a183c98be834"
+dependencies = [
+ "ahash 0.7.7",
+ "metrics-macros",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2671,25 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mobc"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eb49dc5d193287ff80e72a86f34cfb27aae562299d22fea215e06ea1059dd3"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "log",
+ "metrics",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2695,6 +2737,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -2910,6 +2962,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3894,6 +3952,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60da9a72c824ff528dbae0c744d24b9f039dcde49cca9dd2f34438d5b0a1578c"
+
+[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4207,6 +4271,15 @@ dependencies = [
  "is_debug",
  "time",
  "tzdb",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -4560,6 +4633,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4857,6 +4940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -4867,6 +4951,31 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5037,6 +5146,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/kbs/config/kbs-config-grpc.toml
+++ b/kbs/config/kbs-config-grpc.toml
@@ -3,3 +3,4 @@ insecure_api = true
 
 [grpc_config]
 as_addr = "http://127.0.0.1:50004"
+pool_size = 200

--- a/kbs/src/api/Cargo.toml
+++ b/kbs/src/api/Cargo.toml
@@ -15,7 +15,7 @@ opa = ["policy"]
 coco-as = ["as"]
 coco-as-builtin = ["coco-as", "attestation-service/default"]
 coco-as-builtin-no-verifier = ["coco-as", "attestation-service/rvps-builtin"]
-coco-as-grpc = ["coco-as", "tonic", "tonic-build", "prost"]
+coco-as-grpc = ["coco-as", "mobc", "tonic", "tonic-build", "prost"]
 intel-trust-authority-as = ["as", "reqwest", "jsonwebtoken"]
 rustls = ["actix-web/rustls", "dep:rustls", "dep:rustls-pemfile"]
 openssl = ["actix-web/openssl", "dep:openssl"]
@@ -37,12 +37,14 @@ jwt-simple = "0.11.6"
 kbs-types.workspace = true
 lazy_static = "1.4.0"
 log.workspace = true
+mobc = { version = "0.8.3", optional = true }
 prost = { version = "0.11", optional = true }
 rand = "0.8.5"
 reqwest = { version = "0.11", features = ["json"], optional = true }
 rsa = { version = "0.9.2", optional = true, features = ["sha2"] }
 rustls = { version = "0.20.8", optional = true }
 rustls-pemfile = { version = "1.0.4", optional = true }
+scc = "2"
 semver = "1.0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json.workspace = true

--- a/kbs/src/api/src/attestation/coco/grpc.rs
+++ b/kbs/src/api/src/attestation/coco/grpc.rs
@@ -8,8 +8,10 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use kbs_types::{Attestation, Tee};
 use log::info;
+use mobc::{Manager, Pool};
 use serde::Deserialize;
 use serde_json::json;
+use tokio::sync::Mutex;
 use tonic::transport::Channel;
 
 use self::attestation::{
@@ -18,12 +20,11 @@ use self::attestation::{
 };
 
 mod attestation {
-    #![allow(unknown_lints)]
-    #![allow(clippy::derive_partial_eq_without_eq)]
     tonic::include_proto!("attestation");
 }
 
 pub const DEFAULT_AS_ADDR: &str = "http://127.0.0.1:50004";
+pub const DEFAULT_POOL_SIZE: u64 = 100;
 
 pub const COCO_AS_HASH_ALGORITHM: &str = "sha384";
 
@@ -44,44 +45,51 @@ fn to_grpc_tee(tee: Tee) -> GrpcTee {
 #[derive(Clone, Debug, Deserialize)]
 pub struct GrpcConfig {
     as_addr: Option<String>,
+    pool_size: Option<u64>,
 }
 
 impl Default for GrpcConfig {
     fn default() -> Self {
         Self {
             as_addr: Some(DEFAULT_AS_ADDR.to_string()),
+            pool_size: Some(DEFAULT_POOL_SIZE),
         }
     }
 }
 
-pub struct Grpc {
-    inner: AttestationServiceClient<Channel>,
+pub struct GrpcClientPool {
+    pool: Mutex<Pool<GrpcManager>>,
 }
 
-impl Grpc {
-    pub async fn new(config: &GrpcConfig) -> Result<Self> {
-        let as_addr = match &config.as_addr {
-            Some(addr) => addr.clone(),
-            None => {
-                log::info!("Default remote AS address (127.0.0.1:50004) is used");
-                DEFAULT_AS_ADDR.to_string()
-            }
-        };
+impl GrpcClientPool {
+    pub async fn new(config: GrpcConfig) -> Result<Self> {
+        let as_addr = config.as_addr.unwrap_or_else(|| {
+            log::info!("Default remote AS address ({DEFAULT_AS_ADDR}) is used");
+            DEFAULT_AS_ADDR.to_string()
+        });
 
-        info!("connect to remote AS [{as_addr}]");
-        let inner = AttestationServiceClient::connect(as_addr).await?;
-        Ok(Self { inner })
+        let pool_size = config.pool_size.unwrap_or_else(|| {
+            log::info!("Default AS connection pool size ({DEFAULT_POOL_SIZE}) is used");
+            DEFAULT_POOL_SIZE
+        });
+
+        info!("connect to remote AS [{as_addr}] with pool size {pool_size}");
+        let manager = GrpcManager { as_addr };
+        let pool = Mutex::new(Pool::builder().max_open(pool_size).build(manager));
+
+        Ok(Self { pool })
     }
 }
 
 #[async_trait]
-impl Attest for Grpc {
-    async fn set_policy(&mut self, input: &[u8]) -> Result<()> {
+impl Attest for GrpcClientPool {
+    async fn set_policy(&self, input: &[u8]) -> Result<()> {
         let input = String::from_utf8(input.to_vec()).context("parse SetPolicyInput")?;
         let req = tonic::Request::new(SetPolicyRequest { input });
 
-        let _ = self
-            .inner
+        let mut client = { self.pool.lock().await.get().await? };
+
+        client
             .set_attestation_policy(req)
             .await
             .map_err(|e| anyhow!("Set Policy Failed: {:?}", e))?;
@@ -89,7 +97,7 @@ impl Attest for Grpc {
         Ok(())
     }
 
-    async fn verify(&mut self, tee: Tee, nonce: &str, attestation: &str) -> Result<String> {
+    async fn verify(&self, tee: Tee, nonce: &str, attestation: &str) -> Result<String> {
         let attestation: Attestation = serde_json::from_str(attestation)?;
 
         // TODO: align with the guest-components/kbs-protocol side.
@@ -107,13 +115,33 @@ impl Attest for Grpc {
             policy_ids: vec!["default".to_string()],
         });
 
-        let token = self
-            .inner
+        let mut client = { self.pool.lock().await.get().await? };
+
+        let token = client
             .attestation_evaluate(req)
             .await?
             .into_inner()
             .attestation_token;
 
         Ok(token)
+    }
+}
+
+pub struct GrpcManager {
+    as_addr: String,
+}
+
+#[async_trait]
+impl Manager for GrpcManager {
+    type Connection = AttestationServiceClient<Channel>;
+    type Error = tonic::transport::Error;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let connection = AttestationServiceClient::connect(self.as_addr.clone()).await?;
+        std::result::Result::Ok(connection)
+    }
+
+    async fn check(&self, conn: Self::Connection) -> Result<Self::Connection, Self::Error> {
+        std::result::Result::Ok(conn)
     }
 }

--- a/kbs/src/api/src/attestation/intel_trust_authority/mod.rs
+++ b/kbs/src/api/src/attestation/intel_trust_authority/mod.rs
@@ -49,7 +49,7 @@ pub struct IntelTrustAuthority {
 
 #[async_trait]
 impl Attest for IntelTrustAuthority {
-    async fn verify(&mut self, tee: Tee, _nonce: &str, attestation: &str) -> Result<String> {
+    async fn verify(&self, tee: Tee, _nonce: &str, attestation: &str) -> Result<String> {
         if tee != Tee::Tdx && tee != Tee::Sgx {
             bail!("Intel Trust Authority: TEE {tee:?} is not supported.");
         }
@@ -119,7 +119,7 @@ impl Attest for IntelTrustAuthority {
 }
 
 impl IntelTrustAuthority {
-    pub fn new(config: &IntelTrustAuthorityConfig) -> Result<Self> {
+    pub fn new(config: IntelTrustAuthorityConfig) -> Result<Self> {
         let file = File::open(&config.certs_file)
             .map_err(|e| anyhow!("Open certs file failed: {:?}", e))?;
         let reader = BufReader::new(file);

--- a/kbs/src/api/src/http/config.rs
+++ b/kbs/src/api/src/http/config.rs
@@ -11,7 +11,7 @@ pub(crate) async fn attestation_policy(
     input: web::Bytes,
     user_pub_key: web::Data<Option<Ed25519PublicKey>>,
     insecure: web::Data<bool>,
-    attestation_service: web::Data<AttestationService>,
+    attestation_service: web::Data<Arc<AttestationService>>,
 ) -> Result<HttpResponse> {
     if !insecure.get_ref() {
         let user_pub_key = user_pub_key
@@ -25,9 +25,6 @@ pub(crate) async fn attestation_policy(
     }
 
     attestation_service
-        .0
-        .lock()
-        .await
         .set_policy(&input)
         .await
         .map_err(|e| Error::PolicyEndpoint(format!("Set policy error {e}")))?;

--- a/kbs/src/api/src/http/resource.rs
+++ b/kbs/src/api/src/http/resource.rs
@@ -138,12 +138,13 @@ async fn get_attest_claims_from_session(
         .cookie(KBS_SESSION_ID)
         .ok_or(Error::UnAuthenticatedCookie)?;
 
-    let session_map = map.sessions.read().await;
-    let locked_session = session_map
-        .get(cookie.value())
+    let session = map
+        .sessions
+        .get_async(cookie.value())
+        .await
         .ok_or(Error::UnAuthenticatedCookie)?;
 
-    let session = locked_session.lock().await;
+    let session = session.get();
 
     info!("Cookie {} request to get resource", session.id());
 

--- a/kbs/src/api/src/lib.rs
+++ b/kbs/src/api/src/lib.rs
@@ -25,8 +25,8 @@ use jwt_simple::prelude::Ed25519PublicKey;
 #[cfg(feature = "resource")]
 use resource::RepositoryConfig;
 use semver::{BuildMetadata, Prerelease, Version, VersionReq};
-use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::{net::SocketAddr, sync::Arc};
 #[cfg(feature = "resource")]
 use token::AttestationTokenVerifierType;
 
@@ -105,7 +105,7 @@ pub struct ApiServer {
     insecure: bool,
 
     #[cfg(feature = "as")]
-    attestation_service: AttestationService,
+    attestation_service: Arc<AttestationService>,
 
     http_timeout: i64,
     insecure_api: bool,
@@ -126,7 +126,7 @@ impl ApiServer {
         certificate: Option<PathBuf>,
         insecure: bool,
 
-        #[cfg(feature = "as")] attestation_service: &AttestationService,
+        #[cfg(feature = "as")] attestation_service: AttestationService,
 
         http_timeout: i64,
         insecure_api: bool,
@@ -152,7 +152,7 @@ impl ApiServer {
             insecure,
 
             #[cfg(feature = "as")]
-            attestation_service: attestation_service.clone(),
+            attestation_service: Arc::new(attestation_service),
 
             http_timeout,
             insecure_api,

--- a/kbs/src/api/src/session.rs
+++ b/kbs/src/api/src/session.rs
@@ -12,9 +12,6 @@ use base64::Engine;
 use kbs_types::{Request, Tee, TeePubKey};
 use rand::{thread_rng, Rng};
 use semver::Version;
-use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 pub(crate) static KBS_SESSION_ID: &str = "kbs-session-id";
@@ -123,13 +120,13 @@ impl<'a> Session<'a> {
 }
 
 pub(crate) struct SessionMap<'a> {
-    pub sessions: RwLock<HashMap<String, Arc<Mutex<Session<'a>>>>>,
+    pub sessions: scc::HashMap<String, Session<'a>>,
 }
 
 impl<'a> SessionMap<'a> {
     pub fn new() -> Self {
         SessionMap {
-            sessions: RwLock::new(HashMap::new()),
+            sessions: scc::HashMap::new(),
         }
     }
 }

--- a/kbs/src/kbs/src/main.rs
+++ b/kbs/src/kbs/src/main.rs
@@ -43,11 +43,11 @@ async fn main() -> Result<()> {
     let attestation_service = {
         cfg_if::cfg_if! {
             if #[cfg(any(feature = "coco-as-builtin", feature = "coco-as-builtin-no-verifier"))] {
-                AttestationService::new(&kbs_config.as_config.unwrap_or_default()).await?
+                AttestationService::new(kbs_config.as_config.unwrap_or_default()).await?
             } else if #[cfg(feature = "coco-as-grpc")] {
-                AttestationService::new(&kbs_config.grpc_config.unwrap_or_default()).await?
+                AttestationService::new(kbs_config.grpc_config.unwrap_or_default()).await?
             } else if #[cfg(feature = "intel-trust-authority-as")] {
-                AttestationService::new(&kbs_config.intel_trust_authority_config)?
+                AttestationService::new(kbs_config.intel_trust_authority_config)?
             } else {
                 compile_error!("Please enable at least one of the following features: `coco-as-builtin`, `coco-as-builtin-no-verifier`, `coco-as-grpc` or `intel-trust-authority-as` to continue.");
             }
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
         kbs_config.certificate,
         kbs_config.insecure_http,
         #[cfg(feature = "as")]
-        &attestation_service,
+        attestation_service,
         kbs_config.timeout,
         kbs_config.insecure_api,
         #[cfg(feature = "resource")]


### PR DESCRIPTION
Currently we are using a global Mutex to protect the only one attestation service client from unsafe thread sync & send. This brings performance bottle neck.

This commit brings some optimization to promote the performance and stability.

1. Abondon the global Mutex of the attestation service and change the API definition of Attest to non-mut. This would let the developers to handle the concurrency safe inside the concrete attestation-service inside. In this way, we prevent to lock the whole process logic.
2. Bring in a gRPC client pool to grpc-coco-as mode. This will help to avoid errors that caused by runing out all the temporaty ports provided by OS.
3. Replace the Mutex of session map with a concurrency-safe HashMap to avoid bottle neck.

Fixes #256