### PR TITLE
Fix RVPS binary building & push image every merge to main

### DIFF
--- a/.github/workflows/as-build-and-push.yaml
+++ b/.github/workflows/as-build-and-push.yaml
@@ -1,4 +1,4 @@
-name: Build and Push CoCoAS Image
+name: Build and Push CoCoAS / RVPS Image
 
 on:
   push:
@@ -8,6 +8,19 @@ on:
 jobs:
   build_and_push:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker_file: attestation-service/Dockerfile.as-grpc
+            tag: coco-as-grpc
+            name: gRPC CoCo-AS
+          - docker_file: attestation-service/Dockerfile.as-restful
+            tag: coco-as-restful
+            name: RESTful CoCo-AS
+          - docker_file: attestation-service/rvps/Dockerfile
+            tag: rvps
+            name: RVPS
 
     steps:
     - name: Checkout code
@@ -23,12 +36,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build gRPC CoCo-AS Container Image
+    - name: Build ${{ matrix.name }} Container Image
       run: |
         commit_sha=${{ github.sha }}
-        DOCKER_BUILDKIT=1 docker build -t ghcr.io/confidential-containers/staged-images/coco-as-grpc:${commit_sha} -t ghcr.io/confidential-containers/staged-images/coco-as-grpc:latest . -f attestation-service/Dockerfile.as-grpc --push
-
-    - name: Build RESTful CoCo-AS Container Image
-      run: |
-        commit_sha=${{ github.sha }}
-        DOCKER_BUILDKIT=1 docker build -t ghcr.io/confidential-containers/staged-images/coco-as-restful:${commit_sha} -t ghcr.io/confidential-containers/staged-images/coco-as-restful:latest . -f attestation-service/Dockerfile.as-restful --push
+        DOCKER_BUILDKIT=1 docker build -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:${commit_sha} -t ghcr.io/confidential-containers/staged-images/${{ matrix.tag }}:latest . -f ${{ matrix.docker_file }} --push

--- a/attestation-service/attestation-service/src/lib.rs
+++ b/attestation-service/attestation-service/src/lib.rs
@@ -179,7 +179,7 @@ impl AttestationService {
         let reference_data_map = self
             .get_reference_data(flattened_claims.keys())
             .await
-            .map_err(|e| anyhow!("Generate reference data failed{:?}", e))?;
+            .map_err(|e| anyhow!("Generate reference data failed: {:?}", e))?;
 
         let evaluation_report = self
             .policy_engine

--- a/attestation-service/rvps/Dockerfile
+++ b/attestation-service/rvps/Dockerfile
@@ -14,7 +14,7 @@ RUN cargo install --bin rvps --path attestation-service/rvps
 
 FROM debian
 
-LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-service"
+LABEL org.opencontainers.image.source="https://github.com/confidential-containers/kbs"
 
 COPY --from=builder /usr/local/cargo/bin/rvps /usr/local/bin/rvps
 

--- a/attestation-service/rvps/src/bin/rvps.rs
+++ b/attestation-service/rvps/src/bin/rvps.rs
@@ -19,7 +19,7 @@ const DEFAULT_STORAGE: &str = "LocalFs";
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// Underlying storage engine that RVPS uses.
-    #[arg(short, long, default_value = DEFAULT_STORAGE)]
+    #[arg(short = 'c', long, default_value = DEFAULT_STORAGE)]
     pub storage: String,
 
     /// Socket addresses (IP:port) to listen on, e.g. 127.0.0.1:50003.


### PR DESCRIPTION
This PR fixes some bugs for RVPS
1. Avoid duplicated launch parameter flag to prevent the process from panic
2. Fix the Dockerfile LABEL and error information for RVPS.
3. Publish the RVPS image every merge to main so that we can test the KBS cluster in time.