### PR TITLE
e2e-test: enable real TEE on self-hosted runners

### DIFF
--- a/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
+++ b/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
@@ -1,0 +1,58 @@
+name: KBS e2e with az-snp-vtpm TEE
+
+on:
+  push:
+    branches:
+    - main
+  # Note on repository checkout: pull_request_target sets `GITHUB_SHA` to the
+  # "last commit on the PR base branch", meaning that by default `actions/checkout`
+  # is going to checkout the repository main branch. In order to pick up the pull
+  # request code, this workflow uses the `github.event.pull_request.head.sha`
+  # property to get the last commit on the HEAD branch. One limitation of this approach
+  # is that, unlike the `pull_request` event, the checked pull request isn't necessarily
+  # rebased to main (so it is up to the workflow to ensure the pull request is rebased
+  # **before* the workflow is triggering)
+  pull_request_target:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    # This workflow will be run if the pull request is labeled 'test_e2e'
+    - labeled
+    branches:
+    - 'main'
+
+jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'test_e2e')
+    steps:
+    - run: "true"
+
+  checkout-and-rebase:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: main
+
+    - name: Rebase the source
+      run: ./kbs/hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+
+    - name: Archive source
+      run: git archive -o kbs.tar.gz HEAD
+
+    - uses: actions/upload-artifact@v4
+      with:
+        path: ./kbs.tar.gz
+
+  e2e-test:
+    needs:
+    - authorize
+    - checkout-and-rebase
+    uses: confidential-containers/kbs/.github/workflows/kbs-e2e.yml@main
+    with:
+      runs-on: '["self-hosted","azure-cvm"]'
+      tarball: kbs.tar.gz

--- a/.github/workflows/kbs-e2e-sample.yaml
+++ b/.github/workflows/kbs-e2e-sample.yaml
@@ -1,0 +1,25 @@
+name: KBS e2e with sample TEE
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Archive source
+      run: git archive -o kbs.tar.gz HEAD
+
+    - uses: actions/upload-artifact@v4
+      with:
+        path: ./kbs.tar.gz
+
+  e2e-test:
+    needs: checkout
+    uses: confidential-containers/kbs/.github/workflows/kbs-e2e.yml@main
+    with:
+      sample: true
+      tarball: kbs.tar.gz

--- a/.github/workflows/kbs-e2e.yaml
+++ b/.github/workflows/kbs-e2e.yaml
@@ -1,8 +1,19 @@
 name: KBS e2e
 
 on:
-  pull_request:
-    branches: [ "main" ]
+  workflow_call:
+    inputs:
+      sample:
+        type: boolean
+        default: false
+      runs-on:
+        type: string
+        default: '["ubuntu-22.04"]'
+        description: JSON representation of runner labels
+      tarball:
+        type: string
+        description: Artifact containing checked out source from a prior job
+        required: true
 
 # Self-hosted runners do not set -o pipefail otherwise
 defaults:
@@ -11,16 +22,13 @@ defaults:
 
 jobs:
   e2e-test:
-    strategy:
-      matrix:
-        tee:
-        - sample
-        # - az-snp-vtpm
-
-    runs-on: ${{ ((matrix.tee == 'az-snp-vtpm') && fromJSON('["self-hosted","azure-cvm"]')) || 'ubuntu-22.04' }}
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+
+    - name: Extract tarball
+      run: tar xzf ${{ inputs.tarball }}
 
     - uses: actions-rs/toolchain@v1
       with:
@@ -43,14 +51,17 @@ jobs:
 
     - name: Install dependencies
       working-directory: kbs/test
-      run: sudo make install-dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y make --no-install-recommends
+        sudo make install-dependencies
 
     - name: Build bins
       working-directory: kbs/test
       run: make bins
 
     - name: Set cc_kbc sample attester env
-      if: matrix.tee == 'sample'
+      if: inputs.sample == true
       run: echo "AA_SAMPLE_ATTESTER_TEST=1" >> "$GITHUB_ENV"
 
     - name: Run e2e test

--- a/kbs/hack/ci-helper.sh
+++ b/kbs/hack/ci-helper.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TARGET_BRANCH=${TARGET_BRANCH:-main}
+
+function rebase_atop_of_the_latest_target_branch() {
+        if [ -n "${TARGET_BRANCH}" ]; then
+                echo "Rebasing atop of the latest ${TARGET_BRANCH}"
+                # Recover from any previous rebase left halfway
+                git rebase --abort 2> /dev/null || true
+                if ! git rebase "origin/${TARGET_BRANCH}"; then
+                        # if GITHUB_WORKSPACE is defined and an architecture is not equal to x86_64
+                        # (mostly self-hosted runners), then remove the repository
+                        if [ -n "${GITHUB_WORKSPACE:-}" ] && [ "$(uname -m)" != "x86_64" ]; then
+                                echo "Rebase failed, cleaning up a repository for self-hosted runners and exiting"
+                                cd "${GITHUB_WORKSPACE}"/..
+                                sudo rm -rf "${GITHUB_WORKSPACE}"
+                        else
+                                echo "Rebase failed, exiting"
+                        fi
+                        exit 1
+                fi
+        fi
+}
+
+function main() {
+    action="${1:-}"
+
+    case "${action}" in
+        rebase-atop-of-the-latest-target-branch) rebase_atop_of_the_latest_target_branch;;
+        *) >&2 echo "Invalid argument"; exit 2 ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Why

We want to be able to test PRs in a real TEE on self-hosted runners. By
default the tests are executed in the fork from which the PR is crated.
The fork does not have the self-hosted runners which provide the TEE. We
need to run them in the scope of the target repository in a safe fashion
that prevents untrusted PRs from running arbitrary code on self-hosted
runners.

fixes: #223

## How

This change is modelled after simular workflows in kata and CAA repos.

The matrix-based kbs-e2e workflow has been turned into a reusable
workflow that is being called by specific TEE workflows. In this PR that
would be the "sample" and "az-snp-vtpm" TEE.

For a real TEE we follow the following ceremony:
1) verify whether the PR is authorized to run (a maintainer needs to set
   a label on the PR).
2) checkout the main branch from the target
3) rebase the changes from the source atop the main branch (using a
   script copied verbatim from CAA)
4) archive the resulting HEAD and upload it as artifact
5) call the re-usable workflow with the required runners param
6) extract the artifact
7) run the test

For the sample TEE steps 1-3 are replaced by a simple checkout

## Caveats

This yaml spaghetti is very hard to test. So while this passes actionlint,
it might need several iterations to always work.

The reusable workflow is targetting main and we cannot point it to a
fork, so no workflow run will successfully complete in this PR.
