### PR TITLE
e2e: reference kbs-e2e.yaml worfklows locally

### DIFF
--- a/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
+++ b/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
@@ -52,7 +52,7 @@ jobs:
     needs:
     - authorize
     - checkout-and-rebase
-    uses: confidential-containers/kbs/.github/workflows/kbs-e2e.yml@main
+    uses: ./.github/workflows/kbs-e2e.yaml
     with:
       runs-on: '["self-hosted","azure-cvm"]'
       tarball: kbs.tar.gz

--- a/.github/workflows/kbs-e2e-sample.yaml
+++ b/.github/workflows/kbs-e2e-sample.yaml
@@ -19,7 +19,7 @@ jobs:
 
   e2e-test:
     needs: checkout
-    uses: confidential-containers/kbs/.github/workflows/kbs-e2e.yml@main
+    uses: ./.github/workflows/kbs-e2e.yaml
     with:
       sample: true
       tarball: kbs.tar.gz

--- a/.github/workflows/kbs-e2e.yaml
+++ b/.github/workflows/kbs-e2e.yaml
@@ -27,8 +27,11 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
 
+    - name: Debug
+      run: find
+
     - name: Extract tarball
-      run: tar xzf ${{ inputs.tarball }}
+      run: tar xzf ./artifact/${{ inputs.tarball }}
 
     - uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
Context: https://github.com/confidential-containers/kbs/actions/runs/7523718849

The attempt to find the workflow failed because there is a typo (yml => yaml). But we should also reference a workflow in the same repository locally as described here:

https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow

Drive-by fix: artifact-download@v4 puts the artifacts in an `./artifact` subfolder.