### PR TITLE
az-snp-vtpm-verifier: remove report_data padding

### DIFF
--- a/attestation-service/verifier/Cargo.toml
+++ b/attestation-service/verifier/Cargo.toml
@@ -18,7 +18,7 @@ cca-verifier = [ "ear", "veraison-apiclient" ]
 anyhow.workspace = true
 asn1-rs = { version = "0.5.1", optional = true }
 async-trait.workspace = true
-az-snp-vtpm = { version = "0.4", default-features = false, features = ["verifier"], optional = true }
+az-snp-vtpm = { version = "0.4.1", default-features = false, features = ["verifier"], optional = true }
 az-tdx-vtpm = { version = "0.4.1", default-features = false, features = ["verifier"], optional = true }
 base64 = "0.21"
 bincode = "1.3.3"


### PR DESCRIPTION
A TPM quote's qualifyingData (nonce) is not padded to 64 bytes, it's of dynamic size and will be the same size as the passed-in nonce when requesting a Quote. Hence verification will fail using the padded report_data.

Also split up Quote verification into signature and nonce verification, so we can later move verification to upper layers (w/ report_data being part of the claim)