### PR TITLE
AS/verifier: fix csv upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
  "az-tdx-vtpm",
  "base64 0.21.6",
  "codicon",
- "csv-rs",
+ "csv-rs 0.1.0 (git+https://gitee.com/anolis/csv-rs?rev=9d8882e)",
  "hyper",
  "hyper-tls",
  "kbs-types",
@@ -1304,6 +1304,26 @@ dependencies = [
 name = "csv-rs"
 version = "0.1.0"
 source = "git+https://gitee.com/anolis/csv-rs?rev=9d8882e#9d8882e005ab0f64f4e3802a37aebfc61bc4fe32"
+dependencies = [
+ "bitfield 0.13.2",
+ "codicon",
+ "hyper",
+ "hyper-tls",
+ "iocuddle",
+ "libc",
+ "openssl",
+ "openssl-sys",
+ "rand",
+ "serde",
+ "serde-big-array",
+ "static_assertions",
+ "tokio",
+]
+
+[[package]]
+name = "csv-rs"
+version = "0.1.0"
+source = "git+https://github.com/openanolis/csv-rs?rev=9d8882e#9d8882e005ab0f64f4e3802a37aebfc61bc4fe32"
 dependencies = [
  "bitfield 0.13.2",
  "codicon",
@@ -5228,7 +5248,7 @@ dependencies = [
  "byteorder",
  "cfg-if",
  "codicon",
- "csv-rs",
+ "csv-rs 0.1.0 (git+https://github.com/openanolis/csv-rs?rev=9d8882e)",
  "ear",
  "eventlog-rs",
  "hex",

--- a/attestation-service/verifier/Cargo.toml
+++ b/attestation-service/verifier/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1"
 cfg-if = "1.0.0"
 codicon = { version = "3.0", optional = true }
 # TODO: change it to "0.1", once released.
-csv-rs = { git = "https://gitee.com/anolis/csv-rs", rev = "9d8882e", optional = true }
+csv-rs = { git = "https://github.com/openanolis/csv-rs", rev = "9d8882e", optional = true }
 eventlog-rs = { version = "0.1.3", optional = true }
 hex.workspace = true
 jsonwebtoken = "8"


### PR DESCRIPTION
csv-rs uses gitee as upstream which often breaks down for network reasons. After replacing the upstream to GitHub, this commit change the upstream address.

Let's wait https://github.com/confidential-containers/guest-components/pull/447 to be verified and merged first and then rebase the guest-component rev.