### PR TITLE
ci: install libssl-dev for e2e on self-hosted runners

### DIFF
--- a/kbs/test/Makefile
+++ b/kbs/test/Makefile
@@ -27,6 +27,7 @@ install-dependencies:
 		clang \
 		libsgx-dcap-default-qpl \
 		libsgx-dcap-quote-verify-dev \
+		libssl-dev \
 		libtdx-attest-dev \
 		libtss2-dev \
 		openssl \


### PR DESCRIPTION
blocked-by: #309 

The self-hosted runners do not ship with openssl headers, so we need to install them explicitly.