### PR TITLE
ci: fetch the head of a PR in kbs TEE runs

### DIFF
--- a/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
+++ b/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   authorize:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'test_e2e')
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'test_e2e')
     steps:
     - run: "true"
 
@@ -36,9 +36,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: main
+        # fetch main on push, otherwise the head of the PR
+        ref: ${{ github.event_name == 'push' && 'main' || github.event.pull_request.head.sha }}
 
     - name: Rebase the source
+      if: github.event_name != 'push'
       run: ./kbs/hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
 
     - name: Archive source


### PR DESCRIPTION
There is a flaw in the checkout logic of the PR, which will always default to `main`, but it should pick the head of the PRs repo.

The e2e tests were not authorized to run on pushes to main, which has been fixed, too.