### PR TITLE
ci: Add default user for git rebase

### DIFF
--- a/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
+++ b/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
@@ -41,7 +41,9 @@ jobs:
 
     - name: Rebase the source
       if: github.event_name != 'push'
-      run: ./kbs/hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
+        git config --global user.name "GH Actions Workflow"
+        git config --global user.email "<rebase@gh-actions-workflow>"
+        ./kbs/hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
 
     - name: Archive source
       run: git archive -o kbs.tar.gz HEAD


### PR DESCRIPTION
On a github runner rebases might fail because there is no git user configured.

<img width="449" alt="image" src="https://github.com/confidential-containers/kbs/assets/273280/2e711357-8183-49cc-b0f4-a9a43627d5b9">

Adopted a fix from the CAA repo:

https://github.com/confidential-containers/cloud-api-adaptor/blob/a326448163882740fbaf25ceb1b16dafa784636c/hack/ci-helper.sh#L14C1-L19C2