### PR TITLE
ci: introduce actionlint and fix findings

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,11 @@
+name: actionlint
+on: [pull_request]
+jobs:
+  actionlint:
+    name: lint workflow files
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: reviewdog/action-actionlint@v1
+      with:
+        fail_on_error: true

--- a/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
+++ b/.github/workflows/kbs-e2e-az-snp-vtpm.yaml
@@ -41,6 +41,7 @@ jobs:
 
     - name: Rebase the source
       if: github.event_name != 'push'
+      run: |
         git config --global user.name "GH Actions Workflow"
         git config --global user.email "<rebase@gh-actions-workflow>"
         ./kbs/hack/ci-helper.sh rebase-atop-of-the-latest-target-branch

--- a/.github/workflows/kbs-e2e.yaml
+++ b/.github/workflows/kbs-e2e.yaml
@@ -27,9 +27,6 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
 
-    - name: Debug
-      run: find
-
     - name: Extract tarball
       run: tar xzf ./artifact/${{ inputs.tarball }}
 


### PR DESCRIPTION
Sorry about the never-ending stream of CI-related PRs, but launching `pull_request_target` workflows w/ rebases and self-hosted runners is pretty much a shot in the dark (the PRs will run the workflows from the main branch). Actionlint will verify the workflows workflows, so at least obvious problems are caught.