### PR TITLE
docs: Fix typo in cluster documentation

### DIFF
--- a/kbs/docs/cluster.md
+++ b/kbs/docs/cluster.md
@@ -28,7 +28,7 @@ Run the cluster
 docker-compose up -d
 ```
 
-Note that by defaultthe KBS cluster blocks sample evidence.
+Note that by default the KBS cluster blocks sample evidence.
 If you are testing with sample evidence you will need to
 set a more permissive resource policy.
 


### PR DESCRIPTION
This PR fixes a typo in the cluster documentation.