### PR TITLE
kbs/config: add RVPS config

### DIFF
--- a/kbs/config/kbs-config.toml
+++ b/kbs/config/kbs-config.toml
@@ -17,5 +17,9 @@ attestation_token_broker = "Simple"
 [as_config.attestation_token_config]
 duration_min = 5
 
+[as_config.rvps_config]
+store_type = "LocalFs"
+remote_addr = ""
+
 [policy_engine_config]
 policy_path = "/opa/confidential-containers/kbs/policy.rego"


### PR DESCRIPTION
Just like in commit 5cc31e72b91eb, added the RVPS config in kbs/config/kbs-config.toml so that the example on the quickstart.md works.

Fixes #320
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>