### PR TITLE
ci: add az-tdx-vtpm workflow for e2e tests

### DIFF
--- a/.github/workflows/kbs-e2e-az-tdx-vtpm.yaml
+++ b/.github/workflows/kbs-e2e-az-tdx-vtpm.yaml
@@ -1,4 +1,4 @@
-name: KBS e2e with az-snp-vtpm TEE
+name: KBS e2e with az-tdx-vtpm TEE
 
 on:
   push:
@@ -60,5 +60,5 @@ jobs:
     - checkout-and-rebase
     uses: ./.github/workflows/kbs-e2e.yaml
     with:
-      runs-on: '["self-hosted","azure-cvm"]'
+      runs-on: '["self-hosted","azure-cvm-tdx"]'
       tarball: kbs.tar.gz

--- a/.github/workflows/kbs-e2e.yaml
+++ b/.github/workflows/kbs-e2e.yaml
@@ -49,6 +49,12 @@ jobs:
           target/
         key: rust-${{ hashFiles('./Cargo.lock') }}
 
+    - name: Set up SGX/TDX certificates cache
+      uses: actions/cache@v4
+      with:
+        path: /root/.dcap-qcnl
+        key: ${{ runner.os }}-dcap-qcnl
+
     - name: Install dependencies
       working-directory: kbs/test
       run: |

--- a/kbs/test/Makefile
+++ b/kbs/test/Makefile
@@ -1,6 +1,8 @@
 OS := $(shell lsb_release -si)
 RELEASE := $(shell lsb_release -sr)
 SGX_REPO_URL := https://download.01.org/intel-sgx/sgx_repo/ubuntu
+SGX_COLLATERAL_URL := https://api.trustedservices.intel.com/sgx/certification/v4/
+SGX_QCNL_CONFIG := /etc/sgx_default_qcnl.conf
 KBS_REPO_PATH := ./data/repository
 KBS_CONFIG_PATH := ./data/e2e
 MAKEFILE_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -26,13 +28,17 @@ install-dependencies:
 		build-essential \
 		clang \
 		libsgx-dcap-default-qpl \
+		libsgx-dcap-quote-verify \
 		libsgx-dcap-quote-verify-dev \
+		libsgx-urts \
 		libssl-dev \
+		libtdx-attest \
 		libtdx-attest-dev \
 		libtss2-dev \
 		openssl \
 		pkg-config \
-		protobuf-compiler
+		protobuf-compiler && \
+	echo '{"collateral_service": "$(SGX_COLLATERAL_URL)"}' | sudo tee $(SGX_QCNL_CONFIG)
 
 kbs:
 	cd $(PROJECT_DIR) && \


### PR DESCRIPTION
This adds a target for the az-tdx-vtpm TEE.

~TDX verifiers need an SGX quoting environment, for this we need to startup a local certificate caching service (PCCS) and point the quoting config to it.~

~The PCCS itself will need an API key to be able to query certificates from Intel's servers. If the apikey secret is set as a param to the callable workflow, it will install PCCS locally.~

We can use intel's collaterals service directly in the dcap configuration, however we need to add the local cert cache, so the endpoint is not hit by too many requests from the CI.

The workflow itself will not be executed in this PR (only after it has been merged) to test whether it works I ran the following on an Azure TDX VM Ubuntu 22.04 vm.

```bash
sudo apt-get update
sudo apt-get install make -y
git clone https://github.com/mkulke/kbs.git -b mkulke/add-az-tdx-vtpm-e2e-workflow
cd kbs/kbs/test/
sudo make install-dependencies
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
source ~/.cargo/env
wget https://go.dev/dl/go1.22.0.linux-amd64.tar.gz
sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.22.0.linux-amd64.tar.gz
rm go1.22.0.linux-amd64.tar.gz
export PATH=$PATH:/usr/local/go/bin
make bins
make generate-attestation-token-signer
sudo make e2e-test
```