### PR TITLE
kbs: improvements to quickstart and misc

### DIFF
--- a/kbs/Makefile
+++ b/kbs/Makefile
@@ -2,6 +2,8 @@ AS_TYPE ?= coco-as
 HTTPS_CRYPTO ?= rustls
 POLICY_ENGINE ?=
 
+CLI_FEATURES ?= default
+
 COCO_AS_INTEGRATION_TYPE ?= builtin
 
 INSTALL_DESTDIR ?= /usr/local/bin
@@ -28,9 +30,12 @@ passport-resource-kbs:
 	cargo build -p kbs --locked --release --no-default-features --features $(HTTPS_CRYPTO),resource,$(POLICY_ENGINE)
 	mv ../target/release/kbs ../target/release/resource-kbs
 
+.PHONY: cli
+cli:
+	cargo build -p kbs-client --locked --release --no-default-features --features $(CLI_FEATURES)
+
 install-kbs:
 	install -D -m0755 ../target/release/kbs $(INSTALL_DESTDIR)
-	install -D -m0755 ../target/release/kbs-client $(INSTALL_DESTDIR)
 
 install-issuer-kbs:
 	install -D -m0755 ../target/release/issuer-kbs $(INSTALL_DESTDIR)
@@ -38,6 +43,8 @@ install-issuer-kbs:
 
 install-resource-kbs:
 	install -D -m0755 ../target/release/resource-kbs $(INSTALL_DESTDIR)
+
+install-cli:
 	install -D -m0755 ../target/release/kbs-client $(INSTALL_DESTDIR)
 
 uninstall:

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -85,7 +85,7 @@ EOF
 Use `kbs-client` to upload resource data to KBS storage:
 
 ```shell
-kbs-client --url http://127.0.0.1:50000 config --auth-private-key config/private.key set-resource --resource-file test/dummy_data --path default/test/dummy
+kbs-client --url http://127.0.0.1:8080 config --auth-private-key config/private.key set-resource --resource-file test/dummy_data --path default/test/dummy
 ```
 
 Here we assigned a custom path for this resource: `default/test/dummy`.
@@ -94,7 +94,7 @@ Here we assigned a custom path for this resource: `default/test/dummy`.
 
 Run following command to get resource data from KBS:
 ```shell
-kbs-client --url http://127.0.0.1:50000 get-resource --path default/test/dummy
+kbs-client --url http://127.0.0.1:8080 get-resource --path default/test/dummy
 ```
 
 If you run the client outside of a TEE, the sample attester will be used.
@@ -103,7 +103,7 @@ To test the KBS with sample evidence, you'll need to update the resource policy
 to something more permissive.
 This can be done with a command such as
 ```shell
-./kbs-client --url http://127.0.0.1:50000 config --auth-private-key config/private.key  set-resource-policy --policy-file allow_all.rego
+./kbs-client --url http://127.0.0.1:8080 config --auth-private-key config/private.key  set-resource-policy --policy-file allow_all.rego
 ```
 
 ## Passport Mode

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -103,7 +103,7 @@ To test the KBS with sample evidence, you'll need to update the resource policy
 to something more permissive.
 This can be done with a command such as
 ```shell
-./kbs-client --url http://127.0.0.1:8080 config --auth-private-key config/private.key  set-resource-policy --policy-file allow_all.rego
+kbs-client --url http://127.0.0.1:8080 config --auth-private-key config/private.key  set-resource-policy --policy-file sample_policies/allow_all.rego
 ```
 
 ## Passport Mode

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -59,6 +59,12 @@ make background-check-kbs POLICY_ENGINE=opa
 sudo make install-kbs
 ```
 
+Build and install the kbs-client:
+```shell
+make cli
+sudo make install-cli
+```
+
 Start KBS with HTTP server:
 ```shell
 kbs --config-file config/kbs-config.toml

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -67,7 +67,7 @@ sudo make install-cli
 
 Start KBS with HTTP server:
 ```shell
-kbs --config-file config/kbs-config.toml
+sudo kbs --config-file config/kbs-config.toml &
 ```
 
 If you want start KBS with HTTPS server, use `--private-key` and `--certificate`

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -56,7 +56,7 @@ and pass it to the KBS server through startup parameters.
 Build KBS in Background Check mode:
 ```shell
 make background-check-kbs POLICY_ENGINE=opa
-make install-kbs
+sudo make install-kbs
 ```
 
 Start KBS with HTTP server:

--- a/kbs/quickstart.md
+++ b/kbs/quickstart.md
@@ -7,6 +7,19 @@ If you're looking for something even quicker, you might want to deploy the KBS c
 
 ## Prerequisite
 
+Install Rust tooling:
+```shell
+curl https://sh.rustup.rs -sSf | sh
+source "$HOME/.cargo/env"
+```
+
+In order to compile some Go components (e.g. the OPA policy engine), install
+the Go compiler (>= 1.20):
+```shell
+sudo apt-get install -y golang-1.20
+export PATH=/usr/lib/go-1.20/bin:$PATH
+```
+
 Install dependencies:
 ```shell
 curl -L "https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key" | sudo apt-key add -

--- a/kbs/sample_policies/README.md
+++ b/kbs/sample_policies/README.md
@@ -1,0 +1,7 @@
+This directory contains sample policy files to configure the policy engine
+of the KBS. You can use these files to write your own policies.
+
+| File | Description |
+| ---  | ---         |
+|[allow_all.rego](./allow_all.rego)|Equivalent to turning off the policy engine. Release resources unconditionally|
+|[deny_all.rego](./deny_all.rego)|Deny all resources release|

--- a/kbs/sample_policies/allow_all.rego
+++ b/kbs/sample_policies/allow_all.rego
@@ -1,0 +1,5 @@
+
+package policy
+
+default allow = true
+

--- a/kbs/sample_policies/deny_all.rego
+++ b/kbs/sample_policies/deny_all.rego
@@ -1,0 +1,4 @@
+
+package policy
+
+default allow = false

--- a/kbs/tools/client/README.md
+++ b/kbs/tools/client/README.md
@@ -13,7 +13,30 @@ For more sophisticated attestation clients, please refer to [guest components](h
 For help:
 
 ```shell
-./client -h
+kbs-client -h
+```
+
+## Building and installing the client
+
+Build the client binary with support to the default features as:
+
+```shell
+make -C ../../ cli
+```
+
+By default the client is built with support to the sample attester, apart from the
+TEE specific ones. If you want to build it with that sample attester only (this will
+require fewer dependencies and so usually handy for CI) then you can pass the
+`sample_only` feature as:
+
+```shell
+make -C ../../ cli CLI_FEATURES=sample_only
+```
+
+Find the built binary at `../../../target/release/kbs-client`. You can get it
+installed into the system as:
+```shell
+sudo make -C ../../ install-cli
 ```
 
 ## Examples


### PR DESCRIPTION
I'm trying to catch up with latest changes of KBS project by following the [quickstart](https://github.com/confidential-containers/kbs/blob/main/kbs/quickstart.md). From within a fresh Ubuntu 22.04 VM (non TEE), I could run the  instructions for the KBS on background check mode but not before fixing some instructions. I took that opportunity to have some improvements to the doc.