### PR TITLE
kbs/config: use Intel PCS to fetch SGX/TDX quote verification collateral

### DIFF
--- a/kbs/config/sgx_default_qcnl.conf
+++ b/kbs/config/sgx_default_qcnl.conf
@@ -2,15 +2,15 @@
   // *** ATTENTION : This file is in JSON format so the keys are case sensitive. Don't change them.
   
   //PCCS server address
-  "pccs_url": "https://localhost:8081/sgx/certification/v4/"
+  //"pccs_url": "https://localhost:8081/sgx/certification/v4/"
 
   // To accept insecure HTTPS certificate, set this option to false
-  ,"use_secure_cert": true
+  //,"use_secure_cert": true
 
   // You can use the Intel PCS or another PCCS to get quote verification collateral.  Retrieval of PCK 
   // Certificates will always use the PCCS described in pccs_url.  When collateral_service is not defined, both 
   // PCK Certs and verification collateral will be retrieved using pccs_url  
-  //,"collateral_service": "https://api.trustedservices.intel.com/sgx/certification/v4/"
+  "collateral_service": "https://api.trustedservices.intel.com/sgx/certification/v4/"
 
   // If you use a PCCS service to get the quote verification collateral, you can specify which PCCS API version is to be used.
   // The legacy 3.0 API will return CRLs in HEX encoded DER format and the sgx_ql_qve_collateral_t.version will be set to 3.0, while


### PR DESCRIPTION
DRAFT until we figure out the actions caching to stay compliant with the PCS Service terms: "Caching of the Public Certificate Key (PCK) and Trusted Computing Based (TCB) information is required to avoid unnecessary high-frequency calls to the Intel Provisioning Certification Services (PCS). "