### PR TITLE
CI: Fix nightly lint error & fix rust nightly version

### DIFF
--- a/.github/workflows/as-basic.yml
+++ b/.github/workflows/as-basic.yml
@@ -19,11 +19,8 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     name: Check
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - stable
+    env:
+      RUSTC_VERSION: 1.76.0
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
@@ -56,11 +53,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libsgx-dcap-quote-verify-dev
 
-      - name: Install Rust toolchain (${{ matrix.rust }})
+      - name: Install Rust toolchain (${{ env.RUSTC_VERSION }})
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ env.RUSTC_VERSION }}
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/as-e2e.yml
+++ b/.github/workflows/as-e2e.yml
@@ -28,6 +28,7 @@ jobs:
     name: TEE=${{ matrix.restful_tee_enum }} Generate Evidence Dynamically=${{ matrix.generate_evidence }}
     runs-on: ${{ matrix.runner }}
     env:
+      RUSTC_VERSION: 1.76.0
       GRPC_TEE_ENUM: ${{ matrix.grpc_tee_enum }}
       RESTFUL_TEE_ENUM: ${{ matrix.restful_tee_enum }}
     steps:
@@ -36,7 +37,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: ${{ env.RUSTC_VERSION }}
 
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/kbs-docker-e2e.yaml
+++ b/.github/workflows/kbs-docker-e2e.yaml
@@ -12,6 +12,8 @@ env:
 jobs:
   e2e-test:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_VERSION: 1.76.0
     steps:
     - name: Checkout KBS
       uses: actions/checkout@v4
@@ -20,7 +22,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: ${{ env.RUSTC_VERSION }}
 
     - name: Build client
       uses: actions-rs/cargo@v1

--- a/.github/workflows/kbs-e2e.yaml
+++ b/.github/workflows/kbs-e2e.yaml
@@ -23,7 +23,8 @@ defaults:
 jobs:
   e2e-test:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
-
+    env:
+      RUSTC_VERSION: 1.76.0
     steps:
     - uses: actions/download-artifact@v4
 
@@ -33,7 +34,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: ${{ env.RUSTC_VERSION }}
 
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -21,15 +21,9 @@ jobs:
   ci:
     strategy:
       fail-fast: false
-      matrix:
-        rust:
-          - stable
-          - beta
-          - nightly
-        os:
-          - ubuntu-latest
-
-    runs-on: ${{ matrix.os }}
+    env:
+      RUSTC_VERSION: 1.76.0
+    runs-on: ubuntu-latest
 
     steps:
     - name: Code checkout
@@ -39,7 +33,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: ${{ matrix.rust }}
+        toolchain: ${{ env.RUSTC_VERSION }}
         override: true
         components: rustfmt, clippy
         target: x86_64-unknown-linux-gnu

--- a/attestation-service/attestation-service/src/config.rs
+++ b/attestation-service/attestation-service/src/config.rs
@@ -5,7 +5,6 @@ use crate::{
 
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
-use std::convert::TryFrom;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 

--- a/attestation-service/verifier/src/cca/mod.rs
+++ b/attestation-service/verifier/src/cca/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use super::*;
-use anyhow::{anyhow, Context, Result};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use base64::Engine;
 use core::result::Result::Ok;

--- a/attestation-service/verifier/src/csv/mod.rs
+++ b/attestation-service/verifier/src/csv/mod.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{Context, Result};
 use log::{debug, warn};
 extern crate serde;
 use self::serde::{Deserialize, Serialize};

--- a/attestation-service/verifier/src/sample/mod.rs
+++ b/attestation-service/verifier/src/sample/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::{Context, Result};
 use log::debug;
 extern crate serde;
 use self::serde::{Deserialize, Serialize};

--- a/attestation-service/verifier/src/snp/mod.rs
+++ b/attestation-service/verifier/src/snp/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::anyhow;
 use base64::Engine;
 use log::debug;
 extern crate serde;
@@ -255,7 +255,6 @@ pub(crate) fn parse_tee_evidence(report: &AttestationReport) -> TeeEvidenceParse
 mod tests {
     use super::*;
     use openssl::nid::Nid;
-    use sev::firmware::host::CertTableEntry;
 
     #[test]
     fn check_milan_certificates() {

--- a/attestation-service/verifier/src/tdx/eventlog.rs
+++ b/attestation-service/verifier/src/tdx/eventlog.rs
@@ -2,8 +2,6 @@ use anyhow::*;
 use byteorder::{LittleEndian, ReadBytesExt};
 use core::mem::size_of;
 use eventlog_rs::Eventlog;
-use std::convert::{TryFrom, TryInto};
-use std::string::ToString;
 use strum::{Display, EnumString};
 
 #[derive(Debug, Clone, EnumString, Display)]

--- a/attestation-service/verifier/src/tdx/mod.rs
+++ b/attestation-service/verifier/src/tdx/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::anyhow;
 use log::{debug, warn};
 
 use crate::tdx::claims::generate_parsed_claim;
@@ -105,7 +105,6 @@ async fn verify_evidence(
 
 #[cfg(test)]
 mod tests {
-    use crate::tdx::claims::generate_parsed_claim;
 
     use super::*;
     use std::fs;

--- a/attestation-service/verifier/src/tdx/quote.rs
+++ b/attestation-service/verifier/src/tdx/quote.rs
@@ -6,7 +6,6 @@ use qvl::{
     tee_qv_get_collateral, tee_supp_data_descriptor_t, tee_verify_quote,
 };
 use scroll::Pread;
-use std::convert::TryInto;
 use std::mem;
 use std::time::{Duration, SystemTime};
 

--- a/kbs/src/api/src/policy_engine/opa/mod.rs
+++ b/kbs/src/api/src/policy_engine/opa/mod.rs
@@ -110,7 +110,6 @@ impl PolicyEngineInterface for Opa {
 mod tests {
     use super::*;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use base64::Engine;
     use serde_json::json;
 
     fn dummy_input(product_id: &str, svn: u64) -> String {


### PR DESCRIPTION
1. Fixes nightly lint error
2. Follow [the discussion](https://github.com/confidential-containers/confidential-containers/issues/193) from @portersrc , I fix the version of rust nightly compiler in GHA to avoid unexpected CI errors everytime new rust nightly version is released.