### PR TITLE
ci: fix DCAP package install

### DIFF
--- a/.github/workflows/as-basic.yml
+++ b/.github/workflows/as-basic.yml
@@ -18,7 +18,7 @@ jobs:
   basic_ci:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       RUSTC_VERSION: 1.76.0
     steps:
@@ -49,7 +49,7 @@ jobs:
       - name: Install TDX build dependencies
         run: |
           sudo curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-          sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+          sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
           sudo apt-get update
           sudo apt-get install -y libsgx-dcap-quote-verify-dev
 

--- a/.github/workflows/kbs-rust.yml
+++ b/.github/workflows/kbs-rust.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
     env:
       RUSTC_VERSION: 1.76.0
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Code checkout
@@ -50,7 +50,7 @@ jobs:
     - name: Install TDX dependencies
       run: |
         sudo curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-        sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+        sudo echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
         sudo apt-get update
         sudo apt-get install -y libtdx-attest-dev libsgx-dcap-quote-verify-dev
 


### PR DESCRIPTION
ubuntu-latest is not focal anymore and will eventually move to 24.04. Therefore, use a pinned ubuntu-<version> runner and match the DCAP packages repository path with it.

The same fix was done in https://github.com/confidential-containers/guest-components/pull/350