### PR TITLE
docs: fix repo name from kbs to Trustee

### DIFF
--- a/.github/workflows/as-e2e.yml
+++ b/.github/workflows/as-e2e.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
          # TODO: Add real HW-TEE test
-         # See https://github.com/confidential-containers/kbs/issues/223
+         # See https://github.com/confidential-containers/trustee/issues/223
           # - runner: self-hosted
           #   generate_evidence: true
           #   grpc_tee_enum: 3

--- a/attestation-service/README.md
+++ b/attestation-service/README.md
@@ -54,7 +54,7 @@ The AS can be built and imported as a Rust crate into any project providing atte
 As the AS API is not yet fully stable, the AS crate needs to be imported from GitHub directly:
 
 ```toml
-attestation-service = { git = "https://github.com/confidential-containers/kbs" }
+attestation-service = { git = "https://github.com/confidential-containers/trustee" }
 ```
 
 ## Server
@@ -67,8 +67,8 @@ This project provides the Attestation Service binary program that can be run as 
 Build and install AS as a standalone server
 
 ```shell
-git clone https://github.com/confidential-containers/kbs
-cd kbs/attestation-service
+git clone https://github.com/confidential-containers/trustee
+cd trustee/attestation-service
 make && make install
 ```
 
@@ -86,7 +86,7 @@ The AS should be queried with a request containing
 - `init_data_hash_algorithm` - the hasing algorithm used with the other above field
 - `policy_ids` - a list of policies which the AS will use to evaluate the evidence claims
 
-For more details see [gRPC proto](https://github.com/confidential-containers/kbs/blob/main/attestation-service/protos/attestation.proto)
+For more details see [gRPC proto](https://github.com/confidential-containers/trustee/blob/main/attestation-service/protos/attestation.proto)
 
 ### Evidence format:
 

--- a/attestation-service/docs/grpc-as.md
+++ b/attestation-service/docs/grpc-as.md
@@ -14,16 +14,16 @@ Here are the steps of building and running gRPC Attestation Service:
 
 Build and install binary
 ```shell
-git clone https://github.com/confidential-containers/kbs
-cd kbs/attestation-service
+git clone https://github.com/confidential-containers/trustee
+cd trustee/attestation-service
 WORKDIR=$(pwd)
 make && make install
 ```
 
 Build and run container image
 ```shell
-git clone https://github.com/confidential-containers/kbs
-cd kbs
+git clone https://github.com/confidential-containers/trustee
+cd trustee
 docker build -t coco-as:grpc -f attestation-service/Dockerfile.as-grpc .
 ```
 

--- a/attestation-service/docs/restful-as.md
+++ b/attestation-service/docs/restful-as.md
@@ -10,16 +10,16 @@ Here are the steps of building and running RESTful Attestation Service:
 
 Build and install binary
 ```shell
-git clone https://github.com/confidential-containers/kbs
-cd kbs/attestation-service
+git clone https://github.com/confidential-containers/trustee
+cd trustee/attestation-service
 WORKDIR=$(pwd)
 make && make install
 ```
 
 Build and run container image
 ```shell
-git clone https://github.com/confidential-containers/kbs
-cd kbs
+git clone https://github.com/confidential-containers/trustee
+cd trustee
 docker build -t coco-as:restful -f attestation-service/Dockerfile.as-restful .
 ```
 

--- a/attestation-service/rvps/Dockerfile
+++ b/attestation-service/rvps/Dockerfile
@@ -14,7 +14,7 @@ RUN cargo install --bin rvps --path attestation-service/rvps
 
 FROM debian
 
-LABEL org.opencontainers.image.source="https://github.com/confidential-containers/kbs"
+LABEL org.opencontainers.image.source="https://github.com/confidential-containers/trustee/attestation-service"
 
 COPY --from=builder /usr/local/cargo/bin/rvps /usr/local/bin/rvps
 

--- a/attestation-service/rvps/README.md
+++ b/attestation-service/rvps/README.md
@@ -55,8 +55,8 @@ In this way, the RVPS can run as a single service. The [gRPC protos](../protos/r
 We can run using the following command
 
 ```bash
-git clone https://github.com/confidential-containers/kbs
-cd kbs/attestation-service/rvps
+git clone https://github.com/confidential-containers/trustee
+cd trustee/attestation-service/rvps
 make build && sudo make install
 ```
 

--- a/attestation-service/verifier/src/lib.rs
+++ b/attestation-service/verifier/src/lib.rs
@@ -145,7 +145,7 @@ pub trait Verifier {
     /// There will be two claims by default regardless of architectures:
     /// - `init_data_hash`: init data hash of the evidence
     /// - `report_data`: report data of the evidence
-    /// TODO: See https://github.com/confidential-containers/kbs/issues/228
+    /// TODO: See https://github.com/confidential-containers/trustee/issues/228
     async fn evaluate(
         &self,
         evidence: &[u8],

--- a/kbs/docker/Dockerfile.coco-as-grpc
+++ b/kbs/docker/Dockerfile.coco-as-grpc
@@ -15,6 +15,6 @@ RUN cargo install --path kbs/src/kbs --no-default-features --features coco-as-gr
 
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.source="https://github.com/confidential-containers/kbs"
+LABEL org.opencontainers.image.source="https://github.com/confidential-containers/trustee/kbs"
 
 COPY --from=builder /usr/local/cargo/bin/kbs /usr/local/bin/kbs

--- a/kbs/docker/Dockerfile.intel-trust-authority
+++ b/kbs/docker/Dockerfile.intel-trust-authority
@@ -14,7 +14,7 @@ RUN cargo install --path kbs/src/kbs --no-default-features --features intel-trus
 
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.source="https://github.com/confidential-containers/kbs"
+LABEL org.opencontainers.image.source="https://github.com/confidential-containers/trustee/kbs"
 
 RUN apt update && apt install -y ca-certificates
 

--- a/kbs/docs/cluster.md
+++ b/kbs/docs/cluster.md
@@ -1,6 +1,6 @@
 # KBS Cluster
 
-KBS provides a simple cluster defined by `docker-compose`, include itself, [Attestation Service](https://github.com/confidential-containers/kbs/tree/main/attestation-service), [Reference Value Provider Service](https://github.com/confidential-containers/kbs/tree/main/attestation-service/rvps) and [CoCo Keyprovider](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent/coco_keyprovider)
+KBS provides a simple cluster defined by `docker-compose`, include itself, [Attestation Service](https://github.com/confidential-containers/trustee/tree/main/attestation-service), [Reference Value Provider Service](https://github.com/confidential-containers/trustee/tree/main/attestation-service/rvps) and [CoCo Keyprovider](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent/coco_keyprovider)
 
 Users can use very simple command to:
 - launch KBS service.


### PR DESCRIPTION
This commit is for the name-changing of kbs repo.

Related to #250