### PR TITLE
Add configuration file for RVPS and add support for JSON fs storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "clap 4.5.0",
+ "config",
  "env_logger 0.10.2",
  "log",
  "path-clean",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.21"
 cfg-if = "1.0.0"
 chrono = "0.4.19"
 clap = { version = "4", features = ["derive"] }
+config = "0.13.3"
 env_logger = "0.10.0"
 hex = "0.4.3"
 kbs-types = "0.5.3"

--- a/attestation-service/attestation-service/src/config.rs
+++ b/attestation-service/attestation-service/src/config.rs
@@ -1,7 +1,5 @@
-use crate::{
-    rvps::RvpsConfig,
-    token::{AttestationTokenBrokerType, AttestationTokenConfig},
-};
+use crate::rvps::RvpsConfig;
+use crate::token::{AttestationTokenBrokerType, AttestationTokenConfig};
 
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
@@ -57,6 +55,7 @@ impl TryFrom<&Path> for Config {
     ///        "policy_engine": "opa",
     ///        "rvps_config": {
     ///            "store_type": "LocalFs",
+    ///            "store_config": {},
     ///            "remote_addr": ""
     ///        },
     ///        "attestation_token_broker": "Simple",

--- a/attestation-service/attestation-service/src/lib.rs
+++ b/attestation-service/attestation-service/src/lib.rs
@@ -174,6 +174,7 @@ impl AttestationService {
             .map_err(|e| anyhow!("Verifier evaluate failed: {e:?}"))?;
 
         let flattened_claims = flatten_claims(tee, &claims_from_tee_evidence)?;
+        debug!("flattened_claims: {:#?}", flattened_claims);
 
         let tcb_json = serde_json::to_string(&flattened_claims)?;
 
@@ -181,6 +182,7 @@ impl AttestationService {
             .get_reference_data(flattened_claims.keys())
             .await
             .map_err(|e| anyhow!("Generate reference data failed: {:?}", e))?;
+        debug!("reference_data_map: {:#?}", reference_data_map);
 
         let evaluation_report = self
             .policy_engine

--- a/attestation-service/attestation-service/src/lib.rs
+++ b/attestation-service/attestation-service/src/lib.rs
@@ -97,9 +97,7 @@ impl AttestationService {
             .map_err(|_| anyhow!("Policy Engine {} is not supported", &config.policy_engine))?
             .to_policy_engine(config.work_dir.as_path())?;
 
-        let rvps = config
-            .rvps_config
-            .to_rvps()
+        let rvps = rvps::initialize_rvps_client(&config.rvps_config)
             .await
             .context("create rvps failed.")?;
 

--- a/attestation-service/attestation-service/src/rvps/builtin.rs
+++ b/attestation-service/attestation-service/src/rvps/builtin.rs
@@ -1,6 +1,6 @@
 use anyhow::*;
 use async_trait::async_trait;
-use reference_value_provider_service::Core;
+use reference_value_provider_service::{Config, Core};
 
 use super::RvpsApi;
 
@@ -9,8 +9,8 @@ pub struct Rvps {
 }
 
 impl Rvps {
-    pub fn new(store_type: &str) -> Result<Self> {
-        let core = Core::new(store_type)?;
+    pub fn new(config: Config) -> Result<Self> {
+        let core = Core::new(config)?;
         Ok(Self { core })
     }
 }

--- a/attestation-service/attestation-service/src/rvps/mod.rs
+++ b/attestation-service/attestation-service/src/rvps/mod.rs
@@ -32,6 +32,7 @@ pub struct RvpsConfig {
     /// Specify the underlying storage type of RVPS, e.g.
     ///
     /// - `localfs`: store inside local filesystem.
+    /// - `localjson`: store inside local json file.
     ///
     /// Only used when feature `rvps-builtin` is enabled
     #[serde(default = "String::default")]

--- a/attestation-service/rvps/Cargo.toml
+++ b/attestation-service/rvps/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 default = [ "bin" ]
 # Used to build rvps binary
-bin = [ "clap", "env_logger", "prost", "shadow-rs", "tokio", "tonic" ]
+bin = [ "clap", "config", "env_logger", "prost", "shadow-rs", "tokio", "tonic" ]
 
 # Support in-toto provenance (not ready)
 in-toto =[ "path-clean", "sha2" ]
@@ -26,6 +26,7 @@ base64.workspace = true
 cfg-if.workspace = true
 chrono = { workspace = true, features = [ "serde" ] }
 clap = { workspace = true, optional = true }
+config = { workspace = true, optional = true }
 env_logger = { workspace = true, optional = true }
 log.workspace = true
 path-clean = { version = "1.0.1", optional = true }

--- a/attestation-service/rvps/Dockerfile
+++ b/attestation-service/rvps/Dockerfile
@@ -18,7 +18,7 @@ LABEL org.opencontainers.image.source="https://github.com/confidential-container
 
 COPY --from=builder /usr/local/cargo/bin/rvps /usr/local/bin/rvps
 
-CMD ["rvps", "--socket", "0.0.0.0:50003"]
+CMD ["rvps"]
 
 VOLUME /opt/confidential-containers/attestation-service/reference_values/
 

--- a/attestation-service/rvps/README.md
+++ b/attestation-service/rvps/README.md
@@ -60,7 +60,12 @@ cd kbs/attestation-service/rvps
 make build && sudo make install
 ```
 
-To by default listen to `localhost:50003` to wait for requests
+Run RVPS
+```shell
+rvps
+```
+
+By default listen to `localhost:50003` to wait for requests
 
 ### Container Image
 
@@ -74,6 +79,22 @@ Run
 ```bash
 docker run -d -p 50003:50003 rvps
 ```
+
+### Configuration file
+
+RVPS can be launched with a specified configuration file by `-c` flag. A configuration file looks lile
+```json
+{
+    "address": "0.0.0.0:50003",
+    "store_type": "LocalFs",
+    "store_config": {
+        "file_path": "/opt/confidential-containers/attestation-service/reference_values"
+    }
+}
+```
+- `address`: socket listening to requests.
+- `store_type`: backend storage type to store reference values. Currently `LocalFs` and `LocalJson` are supported.
+- `store_config`: optional extra parameters for different kinds of `store_type`. This is also a JSON map object. The concrete content is different due to different `store_type`.
 
 ## Integrate RVPS into AS
 

--- a/attestation-service/rvps/src/bin/server/config.rs
+++ b/attestation-service/rvps/src/bin/server/config.rs
@@ -1,0 +1,43 @@
+use anyhow::{Context, Result};
+use reference_value_provider_service::{config::DEFAULT_STORAGE_TYPE, Config as CrateConfig};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+const DEFAULT_ADDR: &str = "127.0.0.1:50003";
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Config {
+    pub address: String,
+    pub store_type: String,
+    pub store_config: Value,
+}
+
+impl From<Config> for CrateConfig {
+    fn from(val: Config) -> CrateConfig {
+        CrateConfig {
+            store_type: val.store_type,
+            store_config: val.store_config,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            store_type: DEFAULT_STORAGE_TYPE.to_string(),
+            store_config: json!({}),
+            address: DEFAULT_ADDR.to_string(),
+        }
+    }
+}
+
+impl Config {
+    pub fn from_file(config_path: &str) -> Result<Self> {
+        let c = config::Config::builder()
+            .add_source(config::File::with_name(config_path))
+            .build()?;
+
+        let res = c.try_deserialize().context("invalid config")?;
+        Ok(res)
+    }
+}

--- a/attestation-service/rvps/src/bin/server/mod.rs
+++ b/attestation-service/rvps/src/bin/server/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use log::{debug, info};
-use reference_value_provider_service::Core;
+use reference_value_provider_service::{Config, Core};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -14,6 +14,8 @@ use crate::rvps_api::{
     ReferenceValueQueryRequest, ReferenceValueQueryResponse, ReferenceValueRegisterRequest,
     ReferenceValueRegisterResponse,
 };
+
+pub mod config;
 
 pub struct RVPSServer {
     rvps: Arc<Mutex<Core>>,
@@ -74,8 +76,8 @@ impl ReferenceValueProviderService for RVPSServer {
     }
 }
 
-pub async fn start(socket: SocketAddr, storage: &str) -> Result<()> {
-    let service = Core::new(storage)?;
+pub async fn start(socket: SocketAddr, config: Config) -> Result<()> {
+    let service = Core::new(config)?;
     let inner = Arc::new(Mutex::new(service));
     let rvps_server = RVPSServer::new(inner.clone());
 

--- a/attestation-service/rvps/src/config.rs
+++ b/attestation-service/rvps/src/config.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub const DEFAULT_STORAGE_TYPE: &str = "LocalFs";
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Config {
+    pub store_type: String,
+    pub store_config: Value,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            store_type: DEFAULT_STORAGE_TYPE.to_string(),
+            store_config: json!({}),
+        }
+    }
+}

--- a/attestation-service/rvps/src/lib.rs
+++ b/attestation-service/rvps/src/lib.rs
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+pub mod config;
 pub mod extractors;
 pub mod pre_processor;
 pub mod reference_value;
 pub mod store;
+
+pub use config::Config;
 
 pub mod native;
 pub use native::Core;

--- a/attestation-service/rvps/src/native.rs
+++ b/attestation-service/rvps/src/native.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use log::{info, warn};
 use std::time::SystemTime;
 
-use crate::store::StoreType;
+use crate::{store::StoreType, Config};
 
 use super::{
     extractors::{Extractors, ExtractorsImpl},
@@ -25,13 +25,13 @@ pub struct Core {
 
 impl Core {
     /// Instantiate  a new RVPS Core
-    pub fn new(store_type: &str) -> Result<Self> {
+    pub fn new(config: Config) -> Result<Self> {
         let pre_processor = PreProcessor::default();
 
         let extractors = ExtractorsImpl::default();
 
-        let store_type = StoreType::try_from(store_type)?;
-        let store = store_type.to_store()?;
+        let store_type = StoreType::try_from(&config.store_type[..])?;
+        let store = store_type.to_store(config.store_config)?;
 
         Ok(Core {
             pre_processor,

--- a/attestation-service/rvps/src/native.rs
+++ b/attestation-service/rvps/src/native.rs
@@ -62,7 +62,7 @@ impl Core {
 
         let rv = self.extractors.process(message)?;
         for v in rv.iter() {
-            let old = self.store.set(v.name().to_string(), v.clone())?;
+            let old = self.store.set(v.name().to_string(), v.clone()).await?;
             if let Some(old) = old {
                 info!("Old Reference value of {} is replaced.", old.name());
             }
@@ -72,7 +72,7 @@ impl Core {
     }
 
     pub async fn get_digests(&self, name: &str) -> Result<Option<TrustedDigest>> {
-        let rv = self.store.get(name)?;
+        let rv = self.store.get(name).await?;
         match rv {
             None => Ok(None),
             Some(rv) => {

--- a/attestation-service/rvps/src/store/local_json/mod.rs
+++ b/attestation-service/rvps/src/store/local_json/mod.rs
@@ -1,21 +1,65 @@
-use std::fs;
+use std::{fs, path::PathBuf};
 
 use super::Store;
 use crate::ReferenceValue;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use log::debug;
+use serde::Deserialize;
+use serde_json::Value;
 
 const FILE_PATH: &str = "/opt/confidential-containers/attestation-service/reference_values.json";
 
-#[derive(Default)]
-pub struct LocalJson;
+pub struct LocalJson {
+    file_path: String,
+}
+
+fn default_file_path() -> String {
+    FILE_PATH.to_string()
+}
+
+#[derive(Deserialize, Default)]
+struct Config {
+    #[serde(default = "default_file_path")]
+    file_path: String,
+}
+
+impl LocalJson {
+    pub fn new(config: Value) -> Result<Self> {
+        let config: Config = serde_json::from_value(config)?;
+
+        let mut path = PathBuf::new();
+        path.push(&config.file_path);
+
+        let parent_dir = path.parent().ok_or_else(|| {
+            anyhow!("Illegal `file_path` for LocalJson's config without a parent dir.")
+        })?;
+        debug!("create path for LocalJson: {:?}", parent_dir);
+        fs::create_dir_all(parent_dir)?;
+        Ok(Self {
+            file_path: config.file_path,
+        })
+    }
+}
 
 impl Store for LocalJson {
-    fn set(&mut self, _name: String, _rv: ReferenceValue) -> Result<Option<ReferenceValue>> {
-        unimplemented!();
+    fn set(&mut self, name: String, rv: ReferenceValue) -> Result<Option<ReferenceValue>> {
+        let file = fs::read(&self.file_path)?;
+        let mut rvs: Vec<ReferenceValue> = serde_json::from_slice(&file)?;
+        let mut res = None;
+        if let Some(item) = rvs.iter_mut().find(|it| it.name == name) {
+            res = Some(item.to_owned());
+            *item = rv;
+        } else {
+            rvs.push(rv);
+        }
+
+        let contents = serde_json::to_vec(&rvs)?;
+        fs::write(&self.file_path, contents)?;
+        Ok(res)
     }
 
     fn get(&self, name: &str) -> Result<Option<ReferenceValue>> {
-        let file = fs::read(FILE_PATH)?;
+        let file = fs::read(&self.file_path)?;
         let rvs: Vec<ReferenceValue> = serde_json::from_slice(&file)?;
         let rv = rvs.into_iter().find(|rv| rv.name == name);
         Ok(rv)

--- a/attestation-service/rvps/src/store/local_json/mod.rs
+++ b/attestation-service/rvps/src/store/local_json/mod.rs
@@ -1,0 +1,23 @@
+use std::fs;
+
+use super::Store;
+use crate::ReferenceValue;
+use anyhow::Result;
+
+const FILE_PATH: &str = "/opt/confidential-containers/attestation-service/reference_values.json";
+
+#[derive(Default)]
+pub struct LocalJson;
+
+impl Store for LocalJson {
+    fn set(&mut self, _name: String, _rv: ReferenceValue) -> Result<Option<ReferenceValue>> {
+        unimplemented!();
+    }
+
+    fn get(&self, name: &str) -> Result<Option<ReferenceValue>> {
+        let file = fs::read(FILE_PATH)?;
+        let rvs: Vec<ReferenceValue> = serde_json::from_slice(&file)?;
+        let rv = rvs.into_iter().find(|rv| rv.name == name);
+        Ok(rv)
+    }
+}

--- a/attestation-service/rvps/src/store/mod.rs
+++ b/attestation-service/rvps/src/store/mod.rs
@@ -7,6 +7,7 @@
 
 use anyhow::Result;
 use serde::Deserialize;
+use serde_json::Value;
 use strum::EnumString;
 
 use self::local_fs::LocalFs;
@@ -24,10 +25,14 @@ pub enum StoreType {
 }
 
 impl StoreType {
-    pub fn to_store(&self) -> Result<Box<dyn Store + Send + Sync>> {
+    pub fn to_store(&self, config: Value) -> Result<Box<dyn Store + Send + Sync>> {
         match self {
-            StoreType::LocalFs => Ok(Box::<LocalFs>::default() as Box<dyn Store + Send + Sync>),
-            StoreType::LocalJson => Ok(Box::<LocalJson>::default() as Box<dyn Store + Send + Sync>),
+            StoreType::LocalFs => {
+                Ok(Box::new(LocalFs::new(config)?) as Box<dyn Store + Send + Sync>)
+            }
+            StoreType::LocalJson => {
+                Ok(Box::new(LocalJson::new(config)?) as Box<dyn Store + Send + Sync>)
+            }
         }
     }
 }

--- a/attestation-service/rvps/src/store/mod.rs
+++ b/attestation-service/rvps/src/store/mod.rs
@@ -6,6 +6,7 @@
 //! Store is responsible for storing verified Reference Values
 
 use anyhow::Result;
+use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::Value;
 use strum::EnumString;
@@ -42,11 +43,12 @@ impl StoreType {
 /// Store. In more scenarios, RV should be stored in persistent
 /// storage, like database, file and so on. All of the mentioned
 /// forms will have the same interface as following.
+#[async_trait]
 pub trait Store {
     /// Store a reference value. If the given `name` exists,
     /// return the previous `Some<ReferenceValue>`, otherwise return `None`
-    fn set(&mut self, name: String, rv: ReferenceValue) -> Result<Option<ReferenceValue>>;
+    async fn set(&self, name: String, rv: ReferenceValue) -> Result<Option<ReferenceValue>>;
 
     // Retrieve a reference value
-    fn get(&self, name: &str) -> Result<Option<ReferenceValue>>;
+    async fn get(&self, name: &str) -> Result<Option<ReferenceValue>>;
 }

--- a/attestation-service/rvps/src/store/mod.rs
+++ b/attestation-service/rvps/src/store/mod.rs
@@ -10,20 +10,24 @@ use serde::Deserialize;
 use strum::EnumString;
 
 use self::local_fs::LocalFs;
+use self::local_json::LocalJson;
 
 use super::ReferenceValue;
 
 pub mod local_fs;
+pub mod local_json;
 
 #[derive(Deserialize, Debug, Clone, EnumString)]
 pub enum StoreType {
     LocalFs,
+    LocalJson,
 }
 
 impl StoreType {
     pub fn to_store(&self) -> Result<Box<dyn Store + Send + Sync>> {
         match self {
             StoreType::LocalFs => Ok(Box::<LocalFs>::default() as Box<dyn Store + Send + Sync>),
+            StoreType::LocalJson => Ok(Box::<LocalJson>::default() as Box<dyn Store + Send + Sync>),
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - "50003:50003"
     volumes:
       - ./kbs/data/reference-values:/opt/confidential-containers/attestation-service/reference_values:rw
+      - ./kbs/config/rvps.json:/etc/rvps.json:rw
 
   keyprovider:
     image: ghcr.io/confidential-containers/coco-keyprovider:latest

--- a/kbs/config/as-config.json
+++ b/kbs/config/as-config.json
@@ -1,9 +1,8 @@
 {
     "work_dir": "/opt/confidential-containers/attestation-service",
     "policy_engine": "opa",
-    "rvps_store_type": "LocalFs",
     "rvps_config": {
-	"remote_addr":"http://rvps:50003"
+	    "remote_addr":"http://rvps:50003"
     },
     "attestation_token_broker": "Simple",
     "attestation_token_config": {

--- a/kbs/config/kbs-config.toml
+++ b/kbs/config/kbs-config.toml
@@ -11,7 +11,6 @@ dir_path = "/opt/confidential-containers/kbs/repository"
 [as_config]
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
-rvps_store_type = "LocalFs"
 attestation_token_broker = "Simple"
 
 [as_config.attestation_token_config]

--- a/kbs/config/kubernetes/base/as-config.json
+++ b/kbs/config/kubernetes/base/as-config.json
@@ -1,7 +1,6 @@
 {
     "work_dir": "/opt/confidential-containers/attestation-service",
     "policy_engine": "opa",
-    "rvps_store_type": "LocalFs",
     "attestation_token_broker": "Simple",
     "attestation_token_config": {
         "duration_min": 5

--- a/kbs/config/kubernetes/base/kbs-config.toml
+++ b/kbs/config/kubernetes/base/kbs-config.toml
@@ -10,7 +10,6 @@ attestation_token_type = "CoCo"
 [as_config]
 work_dir = "/opt/confidential-containers/attestation-service"
 policy_engine = "opa"
-rvps_store_type = "LocalFs"
 attestation_token_broker = "Simple"
 
 [as_config.attestation_token_config]

--- a/kbs/config/rvps.json
+++ b/kbs/config/rvps.json
@@ -1,0 +1,7 @@
+{
+    "address": "0.0.0.0:50003",
+    "store_type": "LocalFs",
+    "store_config": {
+        "file_path": "/opt/confidential-containers/attestation-service/reference_values"
+    }
+}

--- a/kbs/docs/config.md
+++ b/kbs/docs/config.md
@@ -79,11 +79,12 @@ This section is **optional**. When omitted, a default configuration is used.
 |----------------------------|-----------------------------|-----------------------------------------------------|----------|---------|
 | `work_dir`                 | String                      | The location for Attestation Service to store data. | Yes      | -       |
 | `policy_engine`            | String                      | Policy engine type. Valid values: `opa`             | Yes      | -       |
-| `rvps_store_type`          | String                      | RVPS store type. Valid values: `LocalFs`            | Yes      | -       |
+| `rvps_config`              | [RVPSConfiguration][2]      | RVPS configuration                                  | Yes      | -       |
 | `attestation_token_broker` | String                      | Type of the attestation result token broker.        | Yes      | -       |
 | `attestation_token_config` | [AttestationTokenConfig][1] | Attestation result token configuration.             | Yes      | -       |
 
 [1]: #attestationtokenconfig
+[2]: #rvps-configuration
 
 #### AttestationTokenConfig
 
@@ -104,6 +105,17 @@ This section is **optional**. When omitted, a new RSA key pair is generated and 
 | `key_path`     | String  | RSA Key Pair file (PEM format) path.                     | Yes      | -       |
 | `cert_url`     | String  | RSA Public Key certificate chain (PEM format) URL.       | No       | -       |
 | `cert_path`    | String  | RSA Public Key certificate chain (PEM format) file path. | No       | -       |
+
+#### RVPS Configuration
+
+| Property       | Type                    | Description                                          | Required | Default |
+|----------------|-------------------------|------------------------------------------------------|----------|---------|
+| `remote_addr`  | String                  | Remote RVPS' address. If this is specified, will use a remote RVPS. Or a local RVPS will be configured with `store_type` and `store_config`| Conditional       | -       |
+| `store_type`   | String                  | Used if `remote_addr` is not set. The underlying storage type of RVPS.                                                                     | Conditional       | -       |
+| `store_config` | JSON Map                | Used if `remote_addr` is not set. The optional configurations to the underlying storage.                                                   | Conditional       | -       |
+
+Different `store_type` will have different `store_config` items.
+See the details of `store_config` in [concrete implementations of storages](../../attestation-service/rvps/src/store/).
 
 ### gRPC Attestation
 

--- a/kbs/src/api/Cargo.toml
+++ b/kbs/src/api/Cargo.toml
@@ -30,7 +30,7 @@ attestation-service = { path = "../../../attestation-service/attestation-service
 base64.workspace = true
 cfg-if.workspace = true
 clap = { version = "4.3.21", features = ["derive", "env"] }
-config = "0.13.3"
+config.workspace = true
 env_logger.workspace = true
 jsonwebtoken = { workspace = true, default-features = false, optional = true }
 jwt-simple = "0.11.6"

--- a/kbs/test/data/e2e/kbs.toml
+++ b/kbs/test/data/e2e/kbs.toml
@@ -12,7 +12,6 @@ dir_path = "./data/repository"
 [as_config]
 work_dir = "./data/attestation-service"
 policy_engine = "opa"
-rvps_store_type = "LocalFs"
 attestation_token_broker = "Simple"
 
 [as_config.attestation_token_config]


### PR DESCRIPTION
Close #179 
Close #338 

This PR adds a JSON file storage backend. To leverage this, we need to specify some parameters like the file path of the JSON. Thus also add an overall RVPS config to set different parameters of RVPS. To avoid backward compatibility problems, if no config is provided, a legacy configuration file will be used as default.